### PR TITLE
Fix header mobile unpin

### DIFF
--- a/2019/src/components/HeaderMobile.tsx
+++ b/2019/src/components/HeaderMobile.tsx
@@ -86,6 +86,10 @@ export function InnerHeaderMobile(props: Props) {
   const toggleMenu = useCallback(() => {
     setMenuOpen(!menuOpen)
   }, [menuOpen])
+  const changeLanguage = (language: string) => {
+    setMenuOpen(false)
+    onChangeLanguage(language)
+  }
   return (
     <Box>
       <InnerBox>
@@ -138,7 +142,7 @@ export function InnerHeaderMobile(props: Props) {
                 en: "EN",
               }}
               currentLanguage={i18n.language}
-              onChange={onChangeLanguage}
+              onChange={changeLanguage}
             />
           </LanguageSwitchBox>
           <MenuItem to="/speakers/">{t("speakers")}</MenuItem>

--- a/2019/src/components/HeaderMobile.tsx
+++ b/2019/src/components/HeaderMobile.tsx
@@ -79,77 +79,83 @@ const Path = styled.path.attrs(({ theme }) => ({
   fill: theme.colors.primary,
 }))``
 
-export function HeaderMobile(props: Props) {
+export function InnerHeaderMobile(props: Props) {
   const { onChangeLanguage } = props
   const { t, i18n } = useTranslation()
   const [menuOpen, setMenuOpen] = useState<boolean>(false)
   const toggleMenu = useCallback(() => {
+    console.log('toggle');
     setMenuOpen(!menuOpen)
   }, [menuOpen])
+  return (
+    <Box>
+      <InnerBox>
+        <Brand>
+          <LogoLink to="/">
+            <Logo size={46} />
+          </LogoLink>
+        </Brand>
 
+        <TicketBox>
+          <LinkButton
+            color="primary"
+            to="https://pretix.eu/jsconfjp/2019/"
+            size="inline"
+          >
+            {t("tickets")}
+          </LinkButton>
+        </TicketBox>
+
+        <svg
+          width={48}
+          height={48}
+          viewBox="0,0,100,100"
+          onTouchEnd={toggleMenu}
+        >
+          {menuOpen ? (
+            <Path
+              d={[
+                `M0,5 L5,0 L100,95 L95,100 L0,5`,
+                `M95,0 L100,5 L5,100 L0,95 L95,0`,
+              ].join(" ")}
+            />
+          ) : (
+            <Path
+              d={[
+                `M0,0 L100,0 L100,10 L0,10 L0,0`,
+                `M0,45 L100,45 L100,55 L0,55 L0,0`,
+                `M0,90 L100,90 L100,100 L0,100 L0,0`,
+              ].join(" ")}
+            />
+          )}
+        </svg>
+      </InnerBox>
+      {menuOpen && (
+        <MenuBox>
+          <LanguageSwitchBox>
+            <LanguageSwitch
+              languages={{
+                ja: "日本語",
+                en: "EN",
+              }}
+              currentLanguage={i18n.language}
+              onChange={onChangeLanguage}
+            />
+          </LanguageSwitchBox>
+          <MenuItem to="/speakers/">{t("speakers")}</MenuItem>
+          <MenuItem to="/venue/">{t("venue")}</MenuItem>
+          <MenuItem to="/schedule/">{t("schedule")}</MenuItem>
+          <MenuItem to="/sponsors/">{t("sponsors")}</MenuItem>
+        </MenuBox>
+      )}
+    </Box>
+  )
+}
+
+export function HeaderMobile(props: Props) {
   return (
     <Headroom>
-      <Box>
-        <InnerBox>
-          <Brand>
-            <LogoLink to="/">
-              <Logo size={46} />
-            </LogoLink>
-          </Brand>
-
-          <TicketBox>
-            <LinkButton
-              color="primary"
-              to="https://pretix.eu/jsconfjp/2019/"
-              size="inline"
-            >
-              {t("tickets")}
-            </LinkButton>
-          </TicketBox>
-
-          <svg
-            width={48}
-            height={48}
-            viewBox="0,0,100,100"
-            onTouchEnd={toggleMenu}
-          >
-            {menuOpen ? (
-              <Path
-                d={[
-                  `M0,5 L5,0 L100,95 L95,100 L0,5`,
-                  `M95,0 L100,5 L5,100 L0,95 L95,0`,
-                ].join(" ")}
-              />
-            ) : (
-              <Path
-                d={[
-                  `M0,0 L100,0 L100,10 L0,10 L0,0`,
-                  `M0,45 L100,45 L100,55 L0,55 L0,0`,
-                  `M0,90 L100,90 L100,100 L0,100 L0,0`,
-                ].join(" ")}
-              />
-            )}
-          </svg>
-        </InnerBox>
-        {menuOpen && (
-          <MenuBox>
-            <LanguageSwitchBox>
-              <LanguageSwitch
-                languages={{
-                  ja: "日本語",
-                  en: "EN",
-                }}
-                currentLanguage={i18n.language}
-                onChange={onChangeLanguage}
-              />
-            </LanguageSwitchBox>
-            <MenuItem to="/speakers/">{t("speakers")}</MenuItem>
-            <MenuItem to="/venue/">{t("venue")}</MenuItem>
-            <MenuItem to="/schedule/">{t("schedule")}</MenuItem>
-            <MenuItem to="/sponsors/">{t("sponsors")}</MenuItem>
-          </MenuBox>
-        )}
-      </Box>
+      <InnerHeaderMobile {...props} />
     </Headroom>
   )
 }

--- a/2019/src/components/HeaderMobile.tsx
+++ b/2019/src/components/HeaderMobile.tsx
@@ -84,7 +84,6 @@ export function InnerHeaderMobile(props: Props) {
   const { t, i18n } = useTranslation()
   const [menuOpen, setMenuOpen] = useState<boolean>(false)
   const toggleMenu = useCallback(() => {
-    console.log('toggle');
     setMenuOpen(!menuOpen)
   }, [menuOpen])
   return (


### PR DESCRIPTION
Hi JSConf JP team!

I open this PR because I found that in the mobile view when you scroll down a bit and scroll up to click the Hamburger menu the header will disappear. I think it is really annoying.

![before](https://user-images.githubusercontent.com/9064392/65981388-2d296300-e4a3-11e9-89f0-d822076ecdc4.gif)

If I understand correctly, this behavior is caused by Headroom re-rendering so I separated them from the HeaderMobile.

After that, I found my changes affected the display height.
When you opened a Menu and changed the language, the height between the Headroom and content will be fixed to the size of a Menu. so I decided to make sure the Menu will be disappeared after changing the language.

**This is the final result:**

Clicking Hamburger.
![after](https://user-images.githubusercontent.com/9064392/65981922-54ccfb00-e4a4-11e9-96c5-75c84dfb9d95.gif)

Changing languages.
![languages](https://user-images.githubusercontent.com/9064392/65982413-82667400-e4a5-11e9-901d-32baa6fd9837.gif)



However, you might see it already, there is no expanding space anymore. The Menu will display over the content.

![overlay](https://user-images.githubusercontent.com/9064392/65982896-88a92000-e4a6-11e9-95a0-8ff59d981e51.png)

Feel free to comment, review my code.