### PR TITLE
Fix default language to English

### DIFF
--- a/2019/src/components/Speaker.tsx
+++ b/2019/src/components/Speaker.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { Link } from "gatsby"
 import { useTranslation } from "react-i18next"
 import Image, { FluidObject } from "gatsby-image"
+import { enOrJa } from "../util/languages"
 
 export type TalkType = {
   uuid: string
@@ -70,15 +71,11 @@ export function Speaker(props: Props) {
   const { uuid, title, titleJa } = talk
   const { name } = speaker
 
-  const enOrJa = (enStr: string, jaStr: string) => {
-    return i18n.language === "en" ? enStr || jaStr : jaStr || enStr
-  }
-
   if (!uuid || title === "TBA") {
     return (
       <div>
         <Avatar fluid={avatar} loading="lazy" />
-        <Title lang="en">{enOrJa(title, titleJa)}</Title>
+        <Title lang="en">{enOrJa(i18n)(title, titleJa)}</Title>
         <Name>{name}</Name>
       </div>
     )
@@ -87,7 +84,7 @@ export function Speaker(props: Props) {
   return (
     <LinkContainer to={`talk/${uuid}`}>
       <Avatar fluid={avatar} loading="lazy" />
-      <Title>{enOrJa(title, titleJa)}</Title>
+      <Title>{enOrJa(i18n)(title, titleJa)}</Title>
       <Name>{name}</Name>
     </LinkContainer>
   )

--- a/2019/src/pages/schedule.tsx
+++ b/2019/src/pages/schedule.tsx
@@ -17,6 +17,7 @@ import { TalkType, SpeakerType } from "../components/Speaker"
 import { generateTimetable } from "../util/generateTimetable"
 import { rangeTimeBoxes, escapeTime } from "../util/rangeTimeBoxes"
 import { Dates, times, Rooms, rooms } from "../util/misc"
+import { enOrJa } from "../util/languages"
 
 const Grid = styled.div<{ startsAt: Date; endsAt: Date }>`
   display: grid;
@@ -138,9 +139,6 @@ export default function SchedulePage() {
   const talks: TalkType[] = allTalksYaml.edges.map(({ node }: any) => node)
   const timetable = generateTimetable({ speakers, talks })
   const days = Object.keys(times).sort() as Dates[]
-  const enOrJa = (enStr: string, jaStr: string) => {
-    return i18n.language === "en" ? enStr || jaStr : jaStr || enStr
-  }
   const dateTimeFormatter = new Intl.DateTimeFormat(i18n.language, {
     // @ts-ignore dateStyle' does not exist in type 'DateTimeFormatOptions'
     dateStyle: "medium",
@@ -205,7 +203,7 @@ export default function SchedulePage() {
                       <Text>
                         {s.startsAt}-{s.endsAt}
                       </Text>
-                      <Text>{enOrJa(s.title, s.titleJa) || "TBA"}</Text>
+                      <Text>{enOrJa(i18n)(s.title, s.titleJa) || "TBA"}</Text>
                       {s.speakers.length ? (
                         <Text>
                           by{" "}

--- a/2019/src/templates/speaker.tsx
+++ b/2019/src/templates/speaker.tsx
@@ -12,6 +12,7 @@ import { ResponsiveBox } from "../components/ResponsiveBox"
 import { Breadcrumb } from "../components/Breadcrumb"
 import { SpeakerType, TalkType, AvatarType } from "../components/Speaker"
 import { SubTitle } from "../components/SubTitle"
+import { enOrJa } from "../util/languages"
 
 type Props = {
   pageContext: {
@@ -91,14 +92,11 @@ export default function Speaker(props: Props) {
     day: "2-digit",
   })
   const speakerNames = speakers.map(speaker => speaker.name).join(" and ")
-  const enOrJa = (enStr: string, jaStr: string) => {
-    return i18n.language === "en" ? enStr || jaStr : jaStr || enStr
-  }
 
   return (
     <Layout>
       <SEO
-        title={`${enOrJa(title, titleJa)} - ${speakerNames}`}
+        title={`${enOrJa(i18n)(title, titleJa)} - ${speakerNames}`}
         ogImage={avatars.length ? avatars[0].originalImg : undefined}
       />
       <ResponsiveBox>
@@ -108,12 +106,12 @@ export default function Speaker(props: Props) {
           <SpeakerBox key={speaker.uuid}>
             <Avatar fluid={avatars[i]} loading="eager" />
             <Biography
-              source={enOrJa(speaker.biography, speaker.biographyJa)}
+              source={enOrJa(i18n)(speaker.biography, speaker.biographyJa)}
             />
           </SpeakerBox>
         ))}
         <TalkBox>
-          <TalkTitle>{enOrJa(title, titleJa)}</TalkTitle>
+          <TalkTitle>{enOrJa(i18n)(title, titleJa)}</TalkTitle>
           <p>
             {dateFormatter.format(times[date].startsAt)}, {startsAt} - {endsAt}
             <br />
@@ -128,7 +126,7 @@ export default function Speaker(props: Props) {
             ) : null}
             <br />
           </p>
-          <Description source={enOrJa(description, descriptionJa)} />
+          <Description source={enOrJa(i18n)(description, descriptionJa)} />
         </TalkBox>
       </ResponsiveBox>
     </Layout>

--- a/2019/src/util/languages.ts
+++ b/2019/src/util/languages.ts
@@ -1,0 +1,10 @@
+import i18next from "i18next"
+
+export function enOrJa(i18n: i18next.i18n) {
+  return (enStr: string, jaStr: string) =>
+    isJapanese(i18n.language) && jaStr ? jaStr : enStr
+}
+
+export function isJapanese(lang: string) {
+  return /ja(-\w)*/.test(lang)
+}


### PR DESCRIPTION
It's possible to have `en-us`, `en-au` and so on `en-*` languages so it
would be easier to check the language with `ja`.

So, the issue here is, if we only check `en-*` languages with `=== 'en'`, the default `en` would break for those who set language with `en-us` or so.

| Before | After |
| ------ | ------ |
| <img width="745" alt="image" src="https://user-images.githubusercontent.com/6782666/68547279-10c60200-0423-11ea-85d0-935f720fbcb1.png"> | <img width="758" alt="image" src="https://user-images.githubusercontent.com/6782666/68547282-1a4f6a00-0423-11ea-9ee7-6ed49483417b.png"> |

