### PR TITLE
fix(a11y): lang attribute to be set correctly

### DIFF
--- a/2021/src/components/Header.tsx
+++ b/2021/src/components/Header.tsx
@@ -84,7 +84,7 @@ export function Header(props: Props) {
             <LanguageSwitch
               languages={{
                 ja: "日本語",
-                en: "EN"
+                en: "EN",
               }}
               currentLanguage={i18n.language}
               onChange={onChangeLanguage}

--- a/2021/src/components/Hero.tsx
+++ b/2021/src/components/Hero.tsx
@@ -53,9 +53,9 @@ export function Hero(props: Props) {
     <Box>
       <Logo size={270} alt="JSConf JP Logo" />
       <TextBox>
-        <Title>{title}</Title>
+        <Title lang="en">{title}</Title>
         <SubTitle>{subTitle}</SubTitle>
-        <Paragraph>{description}</Paragraph>
+        <Paragraph lang="en">{description}</Paragraph>
       </TextBox>
     </Box>
   )

--- a/2021/src/components/LanguageSwitch.tsx
+++ b/2021/src/components/LanguageSwitch.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 
 type Props = {
-  languages: Record<string, string>
+  languages: Record<Languages, string>
   currentLanguage: string
   onChange: (lang: string) => void
 }
@@ -27,7 +27,7 @@ const Separator = styled.span`
 
 export function LanguageSwitch(props: Props) {
   const { onChange, currentLanguage, languages } = props
-  const langKeys = Object.keys(languages)
+  const langKeys = Object.keys(languages) as Languages[]
 
   return (
     <>

--- a/2021/src/components/Seo.tsx
+++ b/2021/src/components/Seo.tsx
@@ -6,7 +6,7 @@ type MetaProps = JSX.IntrinsicElements["meta"]
 
 type Props = {
   description?: string
-  lang: "en" | "ja"
+  lang: Languages
   meta: MetaProps[]
   title?: string
   ogImage?: string

--- a/2021/src/pages/index.tsx
+++ b/2021/src/pages/index.tsx
@@ -84,7 +84,7 @@ const SponsorBox = styled.div`
 `
 
 export default function IndexPage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const {
     site,
     allSpeakersYaml,
@@ -179,7 +179,7 @@ export default function IndexPage() {
   return (
     <Layout>
       <WavyBox>
-        <SEO />
+        <SEO lang={i18n.language as Languages} />
         <Container>
           <Centerize>
             <Hero

--- a/2021/types/languages.ts
+++ b/2021/types/languages.ts
@@ -1,0 +1,1 @@
+type Languages = "en" | "ja"


### PR DESCRIPTION
HTML の lang 属性が英語固定になっているので、変更されるようにしました。
[WCAG3.1.1 Language of Page](https://www.w3.org/TR/WCAG21/#language-of-page) に関連するものであり、Android のスクリーンリーダー（TalkBack）で日本語文言がスキップされてしまうバグを解消します。