### PR TITLE
fix: re-render the component on the client side

### DIFF
--- a/2021/src/components/LanguageSwitch.tsx
+++ b/2021/src/components/LanguageSwitch.tsx
@@ -27,26 +27,31 @@ const Separator = styled.span`
 
 export function LanguageSwitch(props: Props) {
   const { onChange, currentLanguage, languages } = props
+  const [hasMounted, setHasMounted] = React.useState(false)
   const langKeys = Object.keys(languages) as Languages[]
 
+  React.useEffect(() => {setHasMounted(true)}, [])
+
   return (
-    <>
-      {langKeys.map((langKey, i) => {
-        return (
-          <React.Fragment key={langKey}>
-            <Lang
-              href={currentLanguage?.startsWith(langKey) ? undefined : "#"}
-              onClick={e => {
-                e.preventDefault()
-                onChange(langKey)
-              }}
-            >
-              {languages[langKey]}
-            </Lang>
-            {i + 1 === langKeys.length ? null : <Separator>/</Separator>}
-          </React.Fragment>
-        )
-      })}
-    </>
+    hasMounted
+      ? <>
+        {langKeys.map((langKey, i) => {
+          return (
+            <React.Fragment key={langKey}>
+              <Lang
+                href={currentLanguage?.startsWith(langKey) ? undefined : "#"}
+                onClick={e => {
+                  e.preventDefault()
+                  onChange(langKey)
+                }}
+              >
+                {languages[langKey]}
+              </Lang>
+              {i + 1 === langKeys.length ? null : <Separator>/</Separator>}
+            </React.Fragment>
+          )
+        })}
+      </>
+    : null
   )
 }


### PR DESCRIPTION
ページ上端の言語選択 UI から `日本語` をクリックした後、ページをリロードしたり再訪したりすると、以下のスクリーンショットの通り、本文が日本語であるにも関わらず言語選択 UI の現在状態が EN となってしまうようでした。

<img src="https://user-images.githubusercontent.com/32808575/137849916-4bd01d37-712d-4f28-a484-42fcaecf5511.png" width="50%">

以下の issue, 記事によると、Gatsby が呼び出す [ReactDOM.hydrate()](https://reactjs.org/docs/react-dom.html#hydrate) は、予め描画した HTML の属性がブラウザで描画した場合と異なっていたとき、ブラウザで描画されたはずの属性が反映されなくなってしまうようでした。
https://github.com/gatsbyjs/gatsby/discussions/17914
https://www.joshwcomeau.com/react/the-perils-of-rehydration/
今回は、この問題により言語選択 UI （ LanguageSwitch ）の a タグの href 属性が反映されなくなっているように見えました。

本 PR で、上の記事で紹介されているものと同様のワークアラウンドを追加してみました。
瑣末で恐縮ですが、ご検討いただけますと幸いです。