### PR TITLE
Fix(2021): enable path prefix option on build

### DIFF
--- a/2021/package.json
+++ b/2021/package.json
@@ -5,7 +5,7 @@
   "repository": "jsconfjp/jsconf.jp",
   "author": "Leko <leko.noor@gmail.com>",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "npm run develop",


### PR DESCRIPTION
> The final step is to build your application with either the --prefix-paths flag or PREFIX_PATHS environment variable, like so:

https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/#build

Gatsbyjs ではbuild時に `--path-prefix` をつけないと `pathPrefix` の設定が反映されないので, https://jsconf.jp/2021/ 2021年のサイトではページ遷移や画像の取得が壊れていたのを修正します.