### PR TITLE
Fix: Fix button style when on smart phone

### DIFF
--- a/2022/src/components/Layout.tsx
+++ b/2022/src/components/Layout.tsx
@@ -22,6 +22,12 @@ const BackToTopBox = styled.div`
   position: absolute;
   bottom: 0;
   right: 40px;
+  @media (max-width: 768px) {
+    position: relative;
+    right: 0px;
+    text-align: center;
+    margin-top: 10px;
+  }
 `
 const OnlyMobile = styled.div`
   ${({ theme }) => theme.breakpoints.largerThanMobile} {


### PR DESCRIPTION
トップページをスマートフォンで表示した時に、
「Join us」ボタンと、「TOPへ戻る」ボタンが重なっていたので修正しました。

レビューお願いいたします 🙇‍♂️ 

- 修正前

<img width="300" alt="スクリーンショット 2022-07-10 16 05 21" src="https://user-images.githubusercontent.com/45593212/178138203-251bab78-b769-4a2b-869f-52b0799badc7.png">



- 修正後

<img width="300" alt="スクリーンショット 2022-07-10 16 04 11" src="https://user-images.githubusercontent.com/45593212/178138193-50d91c25-dfa2-4995-9e97-20b1d25607a6.png">

