### PR TITLE
change: チケットを購入する/Buy Tickets -> 参加登録/Registration

### DIFF
--- a/2022/src/i18n/en.ts
+++ b/2022/src/i18n/en.ts
@@ -27,7 +27,7 @@ export const en = {
     roomB: "Track B",
     roomC: "Track C",
     tickets: "Tickets",
-    buyTickets: "Buy Tickets",
+    buyTickets: "Registration",
     comingSoon: "Coming soon",
     "jp-specified-commercial-transactions-act": "特定商取引法に基づく表示",
     "code-of-conduct": "Code of Conduct",

--- a/2022/src/i18n/ja.ts
+++ b/2022/src/i18n/ja.ts
@@ -13,7 +13,7 @@ export const ja: {
     guestSpeakers: "ゲストスピーカー",
     goToGuests: "スピーカー一覧へ",
     tickets: "チケット",
-    buyTickets: "チケットを購入する",
+    buyTickets: "参加登録",
     callForSpeakers: "トーク募集",
     submitTalk: "トーク申込みフォームへ",
     callForSponsors: "スポンサー募集",


### PR DESCRIPTION
https://jsconf.jp/2022/ トップページのチケット登録の表記を `購入する/Buy Tickets` から `参加登録/Registration` に変更しました。