### PR TITLE
発表時間の表示(長さ)を追加, 発表場所(on-site or remote)の表示を追加, i18nサポート, そのほかデザイン調整

### DIFF
--- a/2023/package-lock.json
+++ b/2023/package-lock.json
@@ -8,6 +8,7 @@
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
+        "date-fns": "^2.30.0",
         "gatsby": "^5.12.7",
         "gatsby-image": "3.11.0",
         "gatsby-plugin-image": "^3.12.1",

--- a/2023/package.json
+++ b/2023/package.json
@@ -25,6 +25,7 @@
     "*.{yml,yaml,ts,json}": "prettier"
   },
   "dependencies": {
+    "date-fns": "^2.30.0",
     "gatsby": "^5.12.7",
     "gatsby-image": "3.11.0",
     "gatsby-plugin-image": "^3.12.1",

--- a/2023/src/components/Speaker.tsx
+++ b/2023/src/components/Speaker.tsx
@@ -30,6 +30,7 @@ export type SpeakerType = {
   presentations: string[]
   github: string
   twitter: string
+  location: string
 }
 
 export type AvatarType = {

--- a/2023/src/i18n/en.ts
+++ b/2023/src/i18n/en.ts
@@ -26,6 +26,8 @@ export const en = {
     roomA: "Track A",
     roomB: "Track B",
     roomC: "Track C",
+    "SpokenLang": "SpokenLangage: ",
+    "Location": "Location: ",
     tickets: "Tickets",
     buyTickets: "Registration",
     comingSoon: "Coming soon",

--- a/2023/src/i18n/ja.ts
+++ b/2023/src/i18n/ja.ts
@@ -22,6 +22,8 @@ export const ja: {
     roomA: "トラックA",
     roomB: "トラックB",
     roomC: "トラックC",
+    "SpokenLang": "発表言語: ",
+    "Location": "登壇場所: ",
     venue: "会場アクセス",
     "venue.name": "九段坂上KSビル",
     "venue.address": "〒102-0073 東京都千代田区九段北1-14-6",

--- a/2023/src/i18n/ja.ts
+++ b/2023/src/i18n/ja.ts
@@ -23,7 +23,7 @@ export const ja: {
     roomB: "トラックB",
     roomC: "トラックC",
     "SpokenLang": "発表言語: ",
-    "Location": "登壇場所: ",
+    "Location": "発表場所: ",
     venue: "会場アクセス",
     "venue.name": "九段坂上KSビル",
     "venue.address": "〒102-0073 東京都千代田区九段北1-14-6",

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -18,6 +18,11 @@ import { rangeTimeBoxes, escapeTime } from "../util/rangeTimeBoxes"
 import { Dates, times, Rooms, rooms } from "../util/misc"
 import { enOrJa } from "../util/languages"
 
+function timeToDate(time: string): Date {
+  const [h, m] = time.split(":")
+  return new Date(2023, 10, 19, parseInt(h), parseInt(m))
+}
+
 const dummyTrack = String.fromCharCode(
   rooms[rooms.length - 1].charCodeAt(0) + 1,
 ) as Rooms
@@ -247,6 +252,9 @@ export default function SchedulePage() {
                 {sessions.map(s => {
                   const hasDescription =
                     s.uuid && (s.speakers.length || s.sponsors.length)
+                  const start = timeToDate(s.startsAt)
+                  const end = timeToDate(s.endsAt)
+                  const diff = differenceInMinutes(end, start)
                   return (
                     <Area
                       // @ts-expect-error
@@ -267,22 +275,8 @@ export default function SchedulePage() {
                           <li id="talkTime">
                             {s.startsAt}-{s.endsAt}
                           </li>
-                          {
-                            (differenceInMinutes(
-                                new Date(2023, 10, 19, parseInt(s.endsAt.split(":")[0]), parseInt(s.endsAt.split(":")[1])),
-                                new Date(2023, 10, 19, parseInt(s.startsAt.split(":")[0]), parseInt(s.startsAt.split(":")[1]))
-                            )) !== 0 ? (
-                              <li id="lengthOfSpokenTime">
-                                {
-                                  "(" +
-                                  (differenceInMinutes(
-                                    new Date(2023, 10, 19, parseInt(s.endsAt.split(":")[0]), parseInt(s.endsAt.split(":")[1])),
-                                    new Date(2023, 10, 19, parseInt(s.startsAt.split(":")[0]), parseInt(s.startsAt.split(":")[1]))
-                                  )) + "min" + ")"
-                                }
-                              </li>
-                            ) : (
-                              ""
+                          {diff > 0 && (
+                            <li id="lengthOfSpokenTime">{`(${diff} min)`}</li>
                           )}
                         </ul>
                       </AreaTitle>

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { useStaticQuery, graphql } from "gatsby"
 import { Link as _Link } from "gatsby-link"
 import flatten from "lodash/flatten"
+import { compareAsc, format, parse, formatDistance, differenceInCalendarDays } from "date-fns"
 
 import { Layout } from "../components/Layout"
 import { SEO } from "../components/Seo"
@@ -104,6 +105,12 @@ const AreaTitle = styled.div`
   }
   li#talkTime {
     list-style: none;
+  }
+  li#lengthOfSpokenTime {
+    font-size: 1.5rem;
+    list-style: none;
+
+    padding: 0.1em 0.1em 0.1em;
   }
 `
 const AreaFooter = styled.div`
@@ -244,6 +251,22 @@ export default function SchedulePage() {
                           <li id="talkTime">
                             {s.startsAt}-{s.endsAt}
                           </li>
+                          {
+                            (formatDistance(
+                              new Date(2023, 10, 19, parseInt(s.endsAt.split(":")[0]), parseInt(s.endsAt.split(":")[1])),
+                              new Date(2023, 10, 19, parseInt(s.startsAt.split(":")[0]), parseInt(s.startsAt.split(":")[1]))
+                            )).split(" ")[0] !== "about" ? (
+                              <li id="lengthOfSpokenTime">
+                                {
+                                  (formatDistance(
+                                    new Date(2023, 10, 19, parseInt(s.endsAt.split(":")[0]), parseInt(s.endsAt.split(":")[1])),
+                                    new Date(2023, 10, 19, parseInt(s.startsAt.split(":")[0]), parseInt(s.startsAt.split(":")[1]))
+                                  )).split(" ")[0] + "min"
+                                }
+                              </li>
+                            ) : (
+                              ""
+                          )}
                         </ul>
                       </AreaTitle>
 

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -133,6 +133,20 @@ const AreaFooter = styled.div`
     border-left: 1px solid #000000;
     border-right: 1px solid #000000;
   }
+  li#speakerLocation {
+    background-color: #f0ffff;
+    font-size: 1.2rem;
+    list-style: none;
+
+    padding: 0.25em 0.5em 0.25em;
+    margin: 0 0 0 0.25em;
+
+    border-radius: 0.5em 0.5em 0.5em 0.5em;
+    border-top: 1px solid #000000;
+    border-bottom: 1px solid #000000;
+    border-left: 1px solid #000000;
+    border-right: 1px solid #000000;
+  }
 `
 
 export default function SchedulePage() {
@@ -145,6 +159,7 @@ export default function SchedulePage() {
             node {
               uuid
               name
+              location
             }
           }
         }
@@ -288,6 +303,14 @@ export default function SchedulePage() {
                             </li>
                           ) : (
                             ""
+                          )}
+                          {s.speakers.map(speaker => (speaker.location != "") ? (
+                            <li id="speakerLocation">
+                              {"Location: " + speaker.location}
+                            </li>
+                            ) : (
+                              ""
+                            )
                           )}
                         </ul>
                       </AreaFooter>

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -98,12 +98,11 @@ const AreaTitle = styled.div`
   color: ${({ theme }) => theme.colors.text};
   ul {
     display: flex;
-    justify-content: space-between;
-
     padding-left: 0;
     margin: 0;
   }
   li#talkTime {
+    margin: 0 0.25em 0 0;
     list-style: none;
   }
   li#lengthOfSpokenTime {
@@ -111,6 +110,7 @@ const AreaTitle = styled.div`
     list-style: none;
 
     padding: 0.1em 0.1em 0.1em;
+    margin: 0 0 0 0.25em;
   }
 `
 const AreaFooter = styled.div`

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -273,10 +273,11 @@ export default function SchedulePage() {
                             )).split(" ")[0] !== "about" ? (
                               <li id="lengthOfSpokenTime">
                                 {
+                                  "(" +
                                   (formatDistance(
                                     new Date(2023, 10, 19, parseInt(s.endsAt.split(":")[0]), parseInt(s.endsAt.split(":")[1])),
                                     new Date(2023, 10, 19, parseInt(s.startsAt.split(":")[0]), parseInt(s.startsAt.split(":")[1]))
-                                  )).split(" ")[0] + "min"
+                                  )).split(" ")[0] + "min" + ")"
                                 }
                               </li>
                             ) : (

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -102,6 +102,7 @@ const AreaTitle = styled.div`
     margin: 0;
   }
   li#talkTime {
+    font-size: 2rem;
     margin: 0 0.25em 0 0;
     list-style: none;
   }
@@ -109,7 +110,7 @@ const AreaTitle = styled.div`
     font-size: 1.5rem;
     list-style: none;
 
-    padding: 0.1em 0.1em 0.1em;
+    padding: 0.25em 0.1em 0.1em;
     margin: 0 0 0 0.25em;
   }
 `

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -301,14 +301,14 @@ export default function SchedulePage() {
                         <ul>
                           {s.spokenLanguage != null ? (
                             <li id="spokenLangage">
-                              {"SpokenLang: " + s.spokenLanguage || ""}
+                              { t("SpokenLang") + s.spokenLanguage || ""}
                             </li>
                           ) : (
                             ""
                           )}
                           {s.speakers.map(speaker => (speaker.location != "") ? (
                             <li id="speakerLocation">
-                              {"Location: " + speaker.location}
+                              {t("Location") + speaker.location}
                             </li>
                             ) : (
                               ""

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { useStaticQuery, graphql } from "gatsby"
 import { Link as _Link } from "gatsby-link"
 import flatten from "lodash/flatten"
-import { formatDistance } from "date-fns"
+import { differenceInMinutes } from "date-fns"
 
 import { Layout } from "../components/Layout"
 import { SEO } from "../components/Seo"
@@ -268,17 +268,17 @@ export default function SchedulePage() {
                             {s.startsAt}-{s.endsAt}
                           </li>
                           {
-                            (formatDistance(
-                              new Date(2023, 10, 19, parseInt(s.endsAt.split(":")[0]), parseInt(s.endsAt.split(":")[1])),
-                              new Date(2023, 10, 19, parseInt(s.startsAt.split(":")[0]), parseInt(s.startsAt.split(":")[1]))
-                            )).split(" ")[0] !== "about" ? (
+                            (differenceInMinutes(
+                                new Date(2023, 10, 19, parseInt(s.endsAt.split(":")[0]), parseInt(s.endsAt.split(":")[1])),
+                                new Date(2023, 10, 19, parseInt(s.startsAt.split(":")[0]), parseInt(s.startsAt.split(":")[1]))
+                            )) !== 0 ? (
                               <li id="lengthOfSpokenTime">
                                 {
                                   "(" +
-                                  (formatDistance(
+                                  (differenceInMinutes(
                                     new Date(2023, 10, 19, parseInt(s.endsAt.split(":")[0]), parseInt(s.endsAt.split(":")[1])),
                                     new Date(2023, 10, 19, parseInt(s.startsAt.split(":")[0]), parseInt(s.startsAt.split(":")[1]))
-                                  )).split(" ")[0] + "min" + ")"
+                                  )) + "min" + ")"
                                 }
                               </li>
                             ) : (

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { useStaticQuery, graphql } from "gatsby"
 import { Link as _Link } from "gatsby-link"
 import flatten from "lodash/flatten"
-import { compareAsc, format, parse, formatDistance, differenceInCalendarDays } from "date-fns"
+import { formatDistance } from "date-fns"
 
 import { Layout } from "../components/Layout"
 import { SEO } from "../components/Seo"

--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -105,12 +105,20 @@ const AreaTitle = styled.div`
   li#talkTime {
     list-style: none;
   }
+`
+const AreaFooter = styled.div`
+  color: ${({ theme }) => theme.colors.text};
+  ul {
+    display: flex;
+    padding-left: 0;
+  }
   li#spokenLangage {
     background-color: #f0ffff;
     font-size: 1.2rem;
     list-style: none;
 
-    padding: 0.1em 0.5em 0.1em;
+    padding: 0.25em 0.5em 0.25em;
+    margin: 0;
 
     border-radius: 0.5em 0.5em 0.5em 0.5em;
     border-top: 1px solid #000000;
@@ -236,14 +244,6 @@ export default function SchedulePage() {
                           <li id="talkTime">
                             {s.startsAt}-{s.endsAt}
                           </li>
-
-                          {s.spokenLanguage != null ? (
-                            <li id="spokenLangage">
-                              {"SpokenLang: " + s.spokenLanguage || ""}
-                            </li>
-                          ) : (
-                            ""
-                          )}
                         </ul>
                       </AreaTitle>
 
@@ -256,6 +256,18 @@ export default function SchedulePage() {
                             .join(" and ")}
                         </Text>
                       ) : null}
+
+                      <AreaFooter>
+                        <ul>
+                          {s.spokenLanguage != null ? (
+                            <li id="spokenLangage">
+                              {"SpokenLang: " + s.spokenLanguage || ""}
+                            </li>
+                          ) : (
+                            ""
+                          )}
+                        </ul>
+                      </AreaFooter>
                     </Area>
                   )
                 })}


### PR DESCRIPTION
issue: #354  #355 

### 変更前の画像

<img width="360" alt="スクリーンショット 2023-10-27 0 43 26" src="https://github.com/jsconfjp/jsconf.jp/assets/48705423/9194da13-7917-417d-aa72-96b431c92f04">

### 変更後の画像

<img width="360" alt="スクリーンショット 2023-10-27 0 43 21" src="https://github.com/jsconfjp/jsconf.jp/assets/48705423/f7cb3e51-6ac4-44d7-abf9-2f9875b67a0a">
