### PR TITLE
Add a crew member & fix typo

### DIFF
--- a/2023/src/data/members.yaml
+++ b/2023/src/data/members.yaml
@@ -40,3 +40,6 @@
 - avatar: https://avatars.githubusercontent.com/u/914122?v=4
   name: Martin Heidegger
   url: https://github.com/martinheidegger
+- avatar: https://github.com/JiaeK.png
+  name: JiaeK
+  url: https://github.com/JiaeK

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ To edit your CFP, please make a pull request refer to [CONTRIBUTING.md](./CONTRI
 
 Please update `{YEAR}/src/data/members.yaml`
 
-### Editting a talk or speaker
+### Editing a talk or speaker
 
 Please update `{YEAR}/src/data/talks.yaml` or `{YEAR}/src/data/speakers.yaml`
 
-### Editting a sponsor
+### Editing a sponsor
 
 Please update `{YEAR}/src/data/sponsors.yaml`
 


### PR DESCRIPTION
今年のJSConf JPにクルーとして参加させていただきますので追加します。
ついでに`READ.md`からちょっとした誤字を見つけたので、修正しました。

This PR adds additional crew member info, and fixes small typo in the `READ.md`.