### PR TITLE
Use Track color in the Schedule Display

### DIFF
--- a/2023/src/components/RoomLegend.tsx
+++ b/2023/src/components/RoomLegend.tsx
@@ -12,6 +12,7 @@ const Box = styled.div`
   ${({ theme }) => theme.breakpoints.mobile} {
     flex-direction: column;
     align-items: flex-start;
+    gap: 1em;
   }
 `
 const RoomBox = styled.div`
@@ -19,10 +20,6 @@ const RoomBox = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-
-  ${({ theme }) => theme.breakpoints.mobile} {
-    margin-bottom: 1em;
-  }
 `
 const Circle = styled.div<{ area: Rooms }>`
   width: 30px;
@@ -38,16 +35,23 @@ const Text = styled.span`
   font-family: ${({ theme }) => theme.fonts.text};
 `
 
-export function RoomLegend() {
+type RoomProps = {
+  room: Rooms
+}
+export const Room = ({ room }: RoomProps) => {
   const { t } = useTranslation()
   return (
-    <Box>
-      {rooms.map(room => (
-        <RoomBox key={room}>
-          <Circle area={room} />
-          <Text>{t(`room${room}`)}</Text>
-        </RoomBox>
-      ))}
-    </Box>
+    <RoomBox key={room}>
+      <Circle area={room} />
+      <Text>{t(`room${room}`)}</Text>
+    </RoomBox>
   )
 }
+
+export const RoomLegend = () => (
+  <Box>
+    {rooms.map(room => (
+      <Room room={room} />
+    ))}
+  </Box>
+)

--- a/2023/src/templates/speaker.tsx
+++ b/2023/src/templates/speaker.tsx
@@ -12,6 +12,8 @@ import { AvatarType } from "../components/Speaker"
 import { SpeakerType, TalkType } from "../data/types"
 import { enOrJa } from "../util/languages"
 import { EventTime } from "../components/EventTime"
+import { Room } from "../components/RoomLegend"
+import { Rooms } from "../util/misc"
 
 type Props = {
   pageContext: {
@@ -62,13 +64,19 @@ const SponsorLogo = styled.img`
     max-width: 100%;
   }
 `
-const TalkBox = styled.div`
+const TalkBox = styled.div<{
+  track: Rooms
+}>`
   font-family: ${({ theme }) => theme.fonts.text};
-  background-color: ${({ theme }) => theme.colors.talkBg};
-  padding: 40px;
+  background-color: ${({ track, theme }) => theme.colors[`room${track}`]};
+  border-left: 5px solid;
+  border-color: ${({ track, theme }) => theme.colors[`room${track}Border`]};
+  padding: 2rem 5rem;
+  position: relative;
+  margin: 0 1.25rem;
 
   ${({ theme }) => theme.breakpoints.mobile} {
-    padding: 2em 1em;
+    padding: 1em 2em;
   }
 `
 const TalkTitle = styled.h2`
@@ -128,12 +136,11 @@ export default function Speaker(props: Props) {
             <Biography>{sponsor.prText}</Biography>
           </SpeakerBox>
         ))}
-        <TalkBox>
+        <Room room={room} />
+        <TalkBox track={room}>
           <TalkTitle>{enOrJa(i18n)(title, titleJa)}</TalkTitle>
           <p>
             <EventTime session={talk} />
-            <br />
-            {t(`room${room}`)}
             <br />
             {t("session.lang.spoken")}: {t(`lang.${spokenLanguage}`)}
             {slideLanguage ? (


### PR DESCRIPTION
Instead of having the one color for all talks in the speaker display this PR uses the color of the Room for the session details

<img width="715" alt="Screen Shot 2023-11-16 at 01 29 16" src="https://github.com/jsconfjp/jsconf.jp/assets/914122/611e59c2-cfc4-4fed-b008-64b3c536732e">
<img width="531" alt="Screen Shot 2023-11-16 at 01 29 22" src="https://github.com/jsconfjp/jsconf.jp/assets/914122/0dd01d81-2378-4a8c-b02a-9ee1582858da">
<img width="646" alt="Screen Shot 2023-11-16 at 01 29 28" src="https://github.com/jsconfjp/jsconf.jp/assets/914122/660599a0-5b3c-4225-9f0e-b44f7f4f2540">
<img width="594" alt="Screen Shot 2023-11-16 at 01 29 34" src="https://github.com/jsconfjp/jsconf.jp/assets/914122/a58c83b8-f5c1-4c66-b533-91f8cf236300">

