### PR TITLE
fix: using translation for speaker breadcrumb

### DIFF
--- a/2023/src/templates/speaker.tsx
+++ b/2023/src/templates/speaker.tsx
@@ -115,7 +115,7 @@ export default function Speaker(props: Props) {
         ogImage={avatars.length ? avatars[0].images.sources : undefined}
       />
       <ResponsiveBox>
-        <Breadcrumb path={[{ label: "speakers", to: "/speakers" }, title]} />
+        <Breadcrumb path={[{ label: t("speakers"), to: "/speakers" }, title]} />
         <Title>{speakerNames}</Title>
         {speakers.map((speaker, i) => (
           <SpeakerBox key={speaker.uuid}>


### PR DESCRIPTION
<img width="306" alt="Screen Shot 2023-11-16 at 03 41 51" src="https://github.com/jsconfjp/jsconf.jp/assets/914122/3fcf476b-e430-4f09-817c-f306982a0a0a">
<img width="224" alt="Screen Shot 2023-11-16 at 03 41 47" src="https://github.com/jsconfjp/jsconf.jp/assets/914122/a5e8cd2d-8033-436f-932e-8e5163d88b72">
