### PR TITLE
a11y スケジュールのトラック名をバブルに

### DIFF
--- a/2023/src/pages/schedule.tsx
+++ b/2023/src/pages/schedule.tsx
@@ -63,11 +63,17 @@ const Area = styled(_Link)<{
   justify-content: stretch;
 
   &::before {
-    content: "";
+    content: "${({ track }) => track}";
+    font-family: ${({ theme }) => theme.fonts.text};
+    font-weight: bold;
+    color: ${({ theme }) => theme.colors.base };
+    font-size: 0.7em;
     position: absolute;
     top: -8px;
     left: -10px;
-    display: inline-block;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
     width: 16px;
     height: 16px;
     border-radius: 100%;


### PR DESCRIPTION
色が見えない人が区別できるように

https://github.com/jsconfjp/jsconf.jp/assets/914122/45ec78b2-6843-4a3a-a219-e8bea9149c94


