### PR TITLE
Refactor/fixes

### DIFF
--- a/2024/gatsby-config.js
+++ b/2024/gatsby-config.js
@@ -20,7 +20,6 @@ module.exports = {
   },
   plugins: [
     `gatsby-plugin-typescript`,
-    `gatsby-plugin-react-helmet`,
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-zopfli`,
     `gatsby-plugin-brotli`,

--- a/2024/package-lock.json
+++ b/2024/package-lock.json
@@ -12,7 +12,6 @@
         "gatsby": "^5.13.4",
         "gatsby-plugin-image": "^3.13.1",
         "gatsby-plugin-manifest": "^5.13.1",
-        "gatsby-plugin-react-helmet": "^6.13.1",
         "gatsby-plugin-sharp": "^5.13.1",
         "gatsby-source-filesystem": "^5.13.1",
         "gatsby-transformer-sharp": "^5.13.1",
@@ -10861,21 +10860,6 @@
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
-      }
-    },
-    "node_modules/gatsby-plugin-react-helmet": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-6.13.1.tgz",
-      "integrity": "sha512-Fwgf2UDOo1LQgw1vUmGmDMK5hXVrIXDR92URzu4DylQWgyfycfQ3D9FdU2JZ8jB6F3OI6Yx6YHC7zL3OAL7iOw==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^5.0.0-next",
-        "react-helmet": "^5.1.3 || ^6.0.0"
       }
     },
     "node_modules/gatsby-plugin-sharp": {

--- a/2024/package-lock.json
+++ b/2024/package-lock.json
@@ -6570,9 +6570,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001615",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001615.tgz",
-      "integrity": "sha512-1IpazM5G3r38meiae0bHRnPhz+CBQ3ZLqbQMtrg+AsTPKAXgW38JNsXkyZ+v8waCsDmPq87lmfun5Q2AGysNEQ==",
+      "version": "1.0.30001669",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
+      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
       "funding": [
         {
           "type": "opencollective",
@@ -6586,7 +6586,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capital-case": {
       "version": "1.0.4",

--- a/2024/package.json
+++ b/2024/package.json
@@ -28,7 +28,6 @@
     "gatsby": "^5.13.4",
     "gatsby-plugin-image": "^3.13.1",
     "gatsby-plugin-manifest": "^5.13.1",
-    "gatsby-plugin-react-helmet": "^6.13.1",
     "gatsby-plugin-sharp": "^5.13.1",
     "gatsby-source-filesystem": "^5.13.1",
     "gatsby-transformer-sharp": "^5.13.1",

--- a/2024/src/components/Layout.tsx
+++ b/2024/src/components/Layout.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback } from "react"
-import styled, { ThemeProvider } from "styled-components"
+import styled, {
+  StyleSheetManager,
+  ThemeProvider,
+  WebTarget,
+} from "styled-components"
 import { useStaticQuery, graphql } from "gatsby"
 import { useTranslation } from "react-i18next"
 
@@ -69,6 +73,11 @@ const BackToTopButton = styled.button`
   background-color: ${({ theme }) => theme.colors.primary};
 `
 
+function shouldForwardProp(_propName: string, _target: WebTarget) {
+  // See: https://styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v6
+  return true
+}
+
 export function Layout({ children, background }: Props) {
   const { t, i18n } = useTranslation()
   const onChangeLanguage = useCallback(
@@ -97,7 +106,7 @@ export function Layout({ children, background }: Props) {
 
   return (
     <ThemeProvider theme={theme}>
-      <>
+      <StyleSheetManager shouldForwardProp={shouldForwardProp}>
         <GlobalStyle />
         <OnlyMobile>
           <HeaderMobile
@@ -130,7 +139,7 @@ export function Layout({ children, background }: Props) {
           </BackToTopBox>
         </MainBox>
         <Footer />
-      </>
+      </StyleSheetManager>
     </ThemeProvider>
   )
 }

--- a/2024/src/components/LinkButton.tsx
+++ b/2024/src/components/LinkButton.tsx
@@ -69,15 +69,15 @@ const ExternalSecondaryBox = styled(ExternalBox)`
 
 export type Props = {
   color?: "primary" | "secondary"
-  size: "inline" | "normal" | "large"
+  size?: "inline" | "normal" | "large"
   to: string
-  disabled: boolean
   onClick?: MouseEventHandler
   children: React.ReactNode
 }
 
 export function LinkButton(props: Props) {
-  const { color, to, size, onClick, children } = props
+  const { color, to, onClick, children } = props
+  const size = props.size ?? "normal"
 
   if (!to?.startsWith("http")) {
     if (color === "primary") {
@@ -130,9 +130,4 @@ export function LinkButton(props: Props) {
       </ExternalBox>
     )
   }
-}
-
-LinkButton.defaultProps = {
-  disabled: false,
-  size: "normal",
 }

--- a/2024/src/components/Logo.tsx
+++ b/2024/src/components/Logo.tsx
@@ -2,15 +2,11 @@ import React from "react"
 import logo from "../images/logo.svg"
 
 type Props = {
-  size: number
+  size?: number
 }
 
-export function Logo(props: Props) {
-  const { size } = props
+export const Logo = (props: Props) => {
+  const size = props.size ?? 125
 
   return <img width={size} height={size} src={logo} alt="JSConf JP" />
-}
-
-Logo.defaultProps = {
-  size: 125,
 }

--- a/2024/src/components/Logo2023.tsx
+++ b/2024/src/components/Logo2023.tsx
@@ -2,15 +2,11 @@ import React from "react"
 import logo2023 from "../images/logo-2023.png"
 
 type Props = {
-  size: number
+  size?: number
 }
 
-export function Logo2023(props: Props) {
-  const { size } = props
+export const Logo2023 = (props: Props) => {
+  const size = props.size ?? 125
 
   return <img width={size} height={size} src={logo2023} alt="JSConf JP 2023" />
-}
-
-Logo2023.defaultProps = {
-  size: 125,
 }

--- a/2024/src/components/OptionalLink.tsx
+++ b/2024/src/components/OptionalLink.tsx
@@ -1,0 +1,20 @@
+import React, { forwardRef } from "react"
+import { Link, GatsbyLinkProps } from "gatsby"
+
+export type OptionalLinkProps<TState> = Omit<
+  GatsbyLinkProps<TState>,
+  "to" | "align"
+> & {
+  to?: string | null
+}
+export const OptionalLink = forwardRef<
+  HTMLAnchorElement,
+  OptionalLinkProps<any>
+>((props, ref) => {
+  const { to, ...rest } = props
+  return to ? (
+    <Link ref={ref as any} to={to} {...rest} />
+  ) : (
+    <a ref={ref as any} {...rest} />
+  )
+})

--- a/2024/src/components/Seo.tsx
+++ b/2024/src/components/Seo.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
+import { useTranslation } from "react-i18next"
 
 type MetaProps = JSX.IntrinsicElements["meta"]
 
@@ -12,8 +12,7 @@ type Props = {
   ogImage?: string
 }
 
-export function SEO({ description, ogImage, lang, meta, title }: Props) {
-  lang ??= "en"
+export function SEO({ description, ogImage, meta, title }: Props) {
   meta ??= []
   description ??= ""
 
@@ -32,63 +31,36 @@ export function SEO({ description, ogImage, lang, meta, title }: Props) {
       }
     }
   `)
+  const {
+    i18n: { language },
+  } = useTranslation()
+  const lang = language ?? "en"
   const defaultOgImage = `${site.siteMetadata.siteUrl}${logo.publicURL}`
   const metaTitle = title || site.siteMetadata.title
   const metaDescription = description || site.siteMetadata.description
   return (
-    <Helmet
-      htmlAttributes={{
-        lang,
-      }}
-      defaultTitle={site.siteMetadata.title}
-      title={title ?? undefined}
-      titleTemplate={`%s | ${site.siteMetadata.title}`}
-      meta={(
-        [
-          {
-            name: `viewport`,
-            content: `width=device-width`,
-          },
-          {
-            name: `description`,
-            content: metaDescription,
-          },
-          {
-            property: `og:title`,
-            content: metaTitle,
-          },
-          {
-            property: `og:description`,
-            content: metaDescription,
-          },
-          {
-            property: `og:image`,
-            content: ogImage
-              ? `${site.siteMetadata.siteUrl}${ogImage}`
-              : defaultOgImage,
-          },
-          {
-            property: `og:type`,
-            content: `website`,
-          },
-          {
-            name: `twitter:card`,
-            content: `summary`,
-          },
-          {
-            name: `twitter:creator`,
-            content: site.siteMetadata.author,
-          },
-          {
-            name: `twitter:title`,
-            content: title,
-          },
-          {
-            name: `twitter:description`,
-            content: metaDescription,
-          },
-        ] as MetaProps[]
-      ).concat(meta)}
-    />
+    <>
+      <html lang={lang} />
+      <title>
+        {title
+          ? `${title} | ${site.siteMetadata.title}`
+          : site.siteMetadata.title}
+      </title>
+      <meta name="description" content={metaDescription} />
+      <meta name="og:description" content={metaDescription} />
+      <meta name="og:title" content={metaTitle} />
+      <meta name="og:type" content="website" />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:creator" content={site.siteMetadata.author} />
+      <meta name="twitter:title" content={title ?? site.siteMetadata.title} />
+      <meta name="twitter:description" content={metaDescription} />
+      <meta name="viewport" content="width=device-width" />
+      <meta
+        name="og:image"
+        content={
+          ogImage ? `${site.siteMetadata.siteUrl}${ogImage}` : defaultOgImage
+        }
+      />
+    </>
   )
 }

--- a/2024/src/components/Seo.tsx
+++ b/2024/src/components/Seo.tsx
@@ -6,13 +6,17 @@ type MetaProps = JSX.IntrinsicElements["meta"]
 
 type Props = {
   description?: string | null
-  lang: Languages
-  meta: MetaProps[]
+  lang?: Languages
+  meta?: MetaProps[]
   title?: string | null
   ogImage?: string
 }
 
 export function SEO({ description, ogImage, lang, meta, title }: Props) {
+  lang ??= "en"
+  meta ??= []
+  description ??= ""
+
   const { site, logo } = useStaticQuery(graphql`
     query {
       site {
@@ -87,10 +91,4 @@ export function SEO({ description, ogImage, lang, meta, title }: Props) {
       ).concat(meta)}
     />
   )
-}
-
-SEO.defaultProps = {
-  lang: `en`,
-  meta: [],
-  description: ``,
 }

--- a/2024/src/gatsby-types.d.ts
+++ b/2024/src/gatsby-types.d.ts
@@ -2053,17 +2053,14 @@ type Query_membersYamlArgs = {
 type Query_siteArgs = {
   buildTime: InputMaybe<DateQueryOperatorInput>;
   children: InputMaybe<NodeFilterListInput>;
-  graphqlTypegen: InputMaybe<SiteGraphqlTypegenFilterInput>;
+  graphqlTypegen: InputMaybe<BooleanQueryOperatorInput>;
   host: InputMaybe<StringQueryOperatorInput>;
   id: InputMaybe<StringQueryOperatorInput>;
   internal: InputMaybe<InternalFilterInput>;
-  jsxRuntime: InputMaybe<StringQueryOperatorInput>;
   parent: InputMaybe<NodeFilterInput>;
   pathPrefix: InputMaybe<StringQueryOperatorInput>;
-  polyfill: InputMaybe<BooleanQueryOperatorInput>;
   port: InputMaybe<IntQueryOperatorInput>;
   siteMetadata: InputMaybe<SiteSiteMetadataFilterInput>;
-  trailingSlash: InputMaybe<StringQueryOperatorInput>;
 };
 
 
@@ -2185,17 +2182,14 @@ type Query_talksYamlArgs = {
 type Site = Node & {
   readonly buildTime: Maybe<Scalars['Date']>;
   readonly children: ReadonlyArray<Node>;
-  readonly graphqlTypegen: Maybe<SiteGraphqlTypegen>;
+  readonly graphqlTypegen: Maybe<Scalars['Boolean']>;
   readonly host: Maybe<Scalars['String']>;
   readonly id: Scalars['ID'];
   readonly internal: Internal;
-  readonly jsxRuntime: Maybe<Scalars['String']>;
   readonly parent: Maybe<Node>;
   readonly pathPrefix: Maybe<Scalars['String']>;
-  readonly polyfill: Maybe<Scalars['Boolean']>;
   readonly port: Maybe<Scalars['Int']>;
   readonly siteMetadata: Maybe<SiteSiteMetadata>;
-  readonly trailingSlash: Maybe<Scalars['String']>;
 };
 
 
@@ -2380,33 +2374,27 @@ type SiteEdge = {
 type SiteFieldSelector = {
   readonly buildTime: InputMaybe<FieldSelectorEnum>;
   readonly children: InputMaybe<NodeFieldSelector>;
-  readonly graphqlTypegen: InputMaybe<SiteGraphqlTypegenFieldSelector>;
+  readonly graphqlTypegen: InputMaybe<FieldSelectorEnum>;
   readonly host: InputMaybe<FieldSelectorEnum>;
   readonly id: InputMaybe<FieldSelectorEnum>;
   readonly internal: InputMaybe<InternalFieldSelector>;
-  readonly jsxRuntime: InputMaybe<FieldSelectorEnum>;
   readonly parent: InputMaybe<NodeFieldSelector>;
   readonly pathPrefix: InputMaybe<FieldSelectorEnum>;
-  readonly polyfill: InputMaybe<FieldSelectorEnum>;
   readonly port: InputMaybe<FieldSelectorEnum>;
   readonly siteMetadata: InputMaybe<SiteSiteMetadataFieldSelector>;
-  readonly trailingSlash: InputMaybe<FieldSelectorEnum>;
 };
 
 type SiteFilterInput = {
   readonly buildTime: InputMaybe<DateQueryOperatorInput>;
   readonly children: InputMaybe<NodeFilterListInput>;
-  readonly graphqlTypegen: InputMaybe<SiteGraphqlTypegenFilterInput>;
+  readonly graphqlTypegen: InputMaybe<BooleanQueryOperatorInput>;
   readonly host: InputMaybe<StringQueryOperatorInput>;
   readonly id: InputMaybe<StringQueryOperatorInput>;
   readonly internal: InputMaybe<InternalFilterInput>;
-  readonly jsxRuntime: InputMaybe<StringQueryOperatorInput>;
   readonly parent: InputMaybe<NodeFilterInput>;
   readonly pathPrefix: InputMaybe<StringQueryOperatorInput>;
-  readonly polyfill: InputMaybe<BooleanQueryOperatorInput>;
   readonly port: InputMaybe<IntQueryOperatorInput>;
   readonly siteMetadata: InputMaybe<SiteSiteMetadataFilterInput>;
-  readonly trailingSlash: InputMaybe<StringQueryOperatorInput>;
 };
 
 type SiteFunction = Node & {
@@ -2549,30 +2537,6 @@ type SiteFunctionSortInput = {
   readonly parent: InputMaybe<NodeSortInput>;
   readonly pluginName: InputMaybe<SortOrderEnum>;
   readonly relativeCompiledFilePath: InputMaybe<SortOrderEnum>;
-};
-
-type SiteGraphqlTypegen = {
-  readonly documentSearchPaths: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>;
-  readonly generateOnBuild: Maybe<Scalars['Boolean']>;
-  readonly typesOutputPath: Maybe<Scalars['String']>;
-};
-
-type SiteGraphqlTypegenFieldSelector = {
-  readonly documentSearchPaths: InputMaybe<FieldSelectorEnum>;
-  readonly generateOnBuild: InputMaybe<FieldSelectorEnum>;
-  readonly typesOutputPath: InputMaybe<FieldSelectorEnum>;
-};
-
-type SiteGraphqlTypegenFilterInput = {
-  readonly documentSearchPaths: InputMaybe<StringQueryOperatorInput>;
-  readonly generateOnBuild: InputMaybe<BooleanQueryOperatorInput>;
-  readonly typesOutputPath: InputMaybe<StringQueryOperatorInput>;
-};
-
-type SiteGraphqlTypegenSortInput = {
-  readonly documentSearchPaths: InputMaybe<SortOrderEnum>;
-  readonly generateOnBuild: InputMaybe<SortOrderEnum>;
-  readonly typesOutputPath: InputMaybe<SortOrderEnum>;
 };
 
 type SiteGroupConnection = {
@@ -2995,17 +2959,14 @@ type SiteSiteMetadataSortInput = {
 type SiteSortInput = {
   readonly buildTime: InputMaybe<SortOrderEnum>;
   readonly children: InputMaybe<NodeSortInput>;
-  readonly graphqlTypegen: InputMaybe<SiteGraphqlTypegenSortInput>;
+  readonly graphqlTypegen: InputMaybe<SortOrderEnum>;
   readonly host: InputMaybe<SortOrderEnum>;
   readonly id: InputMaybe<SortOrderEnum>;
   readonly internal: InputMaybe<InternalSortInput>;
-  readonly jsxRuntime: InputMaybe<SortOrderEnum>;
   readonly parent: InputMaybe<NodeSortInput>;
   readonly pathPrefix: InputMaybe<SortOrderEnum>;
-  readonly polyfill: InputMaybe<SortOrderEnum>;
   readonly port: InputMaybe<SortOrderEnum>;
   readonly siteMetadata: InputMaybe<SiteSiteMetadataSortInput>;
-  readonly trailingSlash: InputMaybe<SortOrderEnum>;
 };
 
 type SortOrderEnum =

--- a/2024/src/gatsby-types.d.ts
+++ b/2024/src/gatsby-types.d.ts
@@ -2053,14 +2053,17 @@ type Query_membersYamlArgs = {
 type Query_siteArgs = {
   buildTime: InputMaybe<DateQueryOperatorInput>;
   children: InputMaybe<NodeFilterListInput>;
-  graphqlTypegen: InputMaybe<BooleanQueryOperatorInput>;
+  graphqlTypegen: InputMaybe<SiteGraphqlTypegenFilterInput>;
   host: InputMaybe<StringQueryOperatorInput>;
   id: InputMaybe<StringQueryOperatorInput>;
   internal: InputMaybe<InternalFilterInput>;
+  jsxRuntime: InputMaybe<StringQueryOperatorInput>;
   parent: InputMaybe<NodeFilterInput>;
   pathPrefix: InputMaybe<StringQueryOperatorInput>;
+  polyfill: InputMaybe<BooleanQueryOperatorInput>;
   port: InputMaybe<IntQueryOperatorInput>;
   siteMetadata: InputMaybe<SiteSiteMetadataFilterInput>;
+  trailingSlash: InputMaybe<StringQueryOperatorInput>;
 };
 
 
@@ -2182,14 +2185,17 @@ type Query_talksYamlArgs = {
 type Site = Node & {
   readonly buildTime: Maybe<Scalars['Date']>;
   readonly children: ReadonlyArray<Node>;
-  readonly graphqlTypegen: Maybe<Scalars['Boolean']>;
+  readonly graphqlTypegen: Maybe<SiteGraphqlTypegen>;
   readonly host: Maybe<Scalars['String']>;
   readonly id: Scalars['ID'];
   readonly internal: Internal;
+  readonly jsxRuntime: Maybe<Scalars['String']>;
   readonly parent: Maybe<Node>;
   readonly pathPrefix: Maybe<Scalars['String']>;
+  readonly polyfill: Maybe<Scalars['Boolean']>;
   readonly port: Maybe<Scalars['Int']>;
   readonly siteMetadata: Maybe<SiteSiteMetadata>;
+  readonly trailingSlash: Maybe<Scalars['String']>;
 };
 
 
@@ -2374,27 +2380,33 @@ type SiteEdge = {
 type SiteFieldSelector = {
   readonly buildTime: InputMaybe<FieldSelectorEnum>;
   readonly children: InputMaybe<NodeFieldSelector>;
-  readonly graphqlTypegen: InputMaybe<FieldSelectorEnum>;
+  readonly graphqlTypegen: InputMaybe<SiteGraphqlTypegenFieldSelector>;
   readonly host: InputMaybe<FieldSelectorEnum>;
   readonly id: InputMaybe<FieldSelectorEnum>;
   readonly internal: InputMaybe<InternalFieldSelector>;
+  readonly jsxRuntime: InputMaybe<FieldSelectorEnum>;
   readonly parent: InputMaybe<NodeFieldSelector>;
   readonly pathPrefix: InputMaybe<FieldSelectorEnum>;
+  readonly polyfill: InputMaybe<FieldSelectorEnum>;
   readonly port: InputMaybe<FieldSelectorEnum>;
   readonly siteMetadata: InputMaybe<SiteSiteMetadataFieldSelector>;
+  readonly trailingSlash: InputMaybe<FieldSelectorEnum>;
 };
 
 type SiteFilterInput = {
   readonly buildTime: InputMaybe<DateQueryOperatorInput>;
   readonly children: InputMaybe<NodeFilterListInput>;
-  readonly graphqlTypegen: InputMaybe<BooleanQueryOperatorInput>;
+  readonly graphqlTypegen: InputMaybe<SiteGraphqlTypegenFilterInput>;
   readonly host: InputMaybe<StringQueryOperatorInput>;
   readonly id: InputMaybe<StringQueryOperatorInput>;
   readonly internal: InputMaybe<InternalFilterInput>;
+  readonly jsxRuntime: InputMaybe<StringQueryOperatorInput>;
   readonly parent: InputMaybe<NodeFilterInput>;
   readonly pathPrefix: InputMaybe<StringQueryOperatorInput>;
+  readonly polyfill: InputMaybe<BooleanQueryOperatorInput>;
   readonly port: InputMaybe<IntQueryOperatorInput>;
   readonly siteMetadata: InputMaybe<SiteSiteMetadataFilterInput>;
+  readonly trailingSlash: InputMaybe<StringQueryOperatorInput>;
 };
 
 type SiteFunction = Node & {
@@ -2537,6 +2549,30 @@ type SiteFunctionSortInput = {
   readonly parent: InputMaybe<NodeSortInput>;
   readonly pluginName: InputMaybe<SortOrderEnum>;
   readonly relativeCompiledFilePath: InputMaybe<SortOrderEnum>;
+};
+
+type SiteGraphqlTypegen = {
+  readonly documentSearchPaths: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>;
+  readonly generateOnBuild: Maybe<Scalars['Boolean']>;
+  readonly typesOutputPath: Maybe<Scalars['String']>;
+};
+
+type SiteGraphqlTypegenFieldSelector = {
+  readonly documentSearchPaths: InputMaybe<FieldSelectorEnum>;
+  readonly generateOnBuild: InputMaybe<FieldSelectorEnum>;
+  readonly typesOutputPath: InputMaybe<FieldSelectorEnum>;
+};
+
+type SiteGraphqlTypegenFilterInput = {
+  readonly documentSearchPaths: InputMaybe<StringQueryOperatorInput>;
+  readonly generateOnBuild: InputMaybe<BooleanQueryOperatorInput>;
+  readonly typesOutputPath: InputMaybe<StringQueryOperatorInput>;
+};
+
+type SiteGraphqlTypegenSortInput = {
+  readonly documentSearchPaths: InputMaybe<SortOrderEnum>;
+  readonly generateOnBuild: InputMaybe<SortOrderEnum>;
+  readonly typesOutputPath: InputMaybe<SortOrderEnum>;
 };
 
 type SiteGroupConnection = {
@@ -2959,14 +2995,17 @@ type SiteSiteMetadataSortInput = {
 type SiteSortInput = {
   readonly buildTime: InputMaybe<SortOrderEnum>;
   readonly children: InputMaybe<NodeSortInput>;
-  readonly graphqlTypegen: InputMaybe<SortOrderEnum>;
+  readonly graphqlTypegen: InputMaybe<SiteGraphqlTypegenSortInput>;
   readonly host: InputMaybe<SortOrderEnum>;
   readonly id: InputMaybe<SortOrderEnum>;
   readonly internal: InputMaybe<InternalSortInput>;
+  readonly jsxRuntime: InputMaybe<SortOrderEnum>;
   readonly parent: InputMaybe<NodeSortInput>;
   readonly pathPrefix: InputMaybe<SortOrderEnum>;
+  readonly polyfill: InputMaybe<SortOrderEnum>;
   readonly port: InputMaybe<SortOrderEnum>;
   readonly siteMetadata: InputMaybe<SiteSiteMetadataSortInput>;
+  readonly trailingSlash: InputMaybe<SortOrderEnum>;
 };
 
 type SortOrderEnum =

--- a/2024/src/pages/index.tsx
+++ b/2024/src/pages/index.tsx
@@ -97,6 +97,8 @@ const SponsorBox = styled.div`
   }
 `
 
+export const Head = () => <SEO />
+
 export default function IndexPage() {
   const { t, i18n } = useTranslation()
   const {
@@ -295,7 +297,6 @@ export default function IndexPage() {
   return (
     <Layout>
       <WavyBox>
-        <SEO lang={i18n.language as Languages} />
         <Container>
           <Centerize>
             <Hero

--- a/2024/src/pages/index.tsx
+++ b/2024/src/pages/index.tsx
@@ -261,7 +261,7 @@ export default function IndexPage() {
       subTitle: t("callForSponsors"),
       available: site.siteMetadata.sponsorFormUrl,
       render: () =>
-        site.siteMetadata.sponsorFormUrl ? (
+        false ? (
           <LinkButton
             color="primary"
             size="large"
@@ -270,7 +270,7 @@ export default function IndexPage() {
             {t("becomeASponsor")}
           </LinkButton>
         ) : (
-          <LinkButton size="large" disabled to={""}>
+          <LinkButton size="large" to={""}>
             {t("comingSoon")}
           </LinkButton>
         ),

--- a/2024/src/pages/schedule.tsx
+++ b/2024/src/pages/schedule.tsx
@@ -163,6 +163,11 @@ const AreaFooter = styled.div`
   margin-top: 2.5rem;
 `
 
+export const Head = () => {
+  const { t } = useTranslation()
+  return <SEO title={t("schedule")} description={t("schedule.description")} />
+}
+
 export default function SchedulePage() {
   const { t, i18n } = useTranslation()
   const enOrJa = useEnOrJa()
@@ -267,7 +272,6 @@ export default function SchedulePage() {
 
   return (
     <Layout>
-      <SEO title={t("schedule")} description={t("schedule.description")} />
       <ResponsiveBox>
         <Breadcrumb path={[t("schedule")]} />
         <Title>{t("schedule")}</Title>

--- a/2024/src/pages/schedule.tsx
+++ b/2024/src/pages/schedule.tsx
@@ -24,15 +24,26 @@ import { Tags } from "../components/Tags"
 const dummyTrack = String.fromCharCode(
   rooms[rooms.length - 1].charCodeAt(0) + 1,
 ) as Rooms
-const Grid = styled.div<{ startsAt: Date; endsAt: Date }>`
+
+function getHours(time: string | Date) {
+  if (typeof time === "string") {
+    return parseInt(time.split(":")[0])
+  }
+  return time.getHours()
+}
+
+const Grid = styled.div<{
+  "starts-at": Date | string
+  "ends-at": Date | string
+}>`
   display: grid;
   grid-column-gap: 1em;
   grid-template-columns: ${rooms
     .concat(dummyTrack)
     .map(r => `[${r}]`)
     .join(" 1fr ")};
-  grid-template-rows: ${({ startsAt, endsAt }) =>
-    rangeTimeBoxes(5, startsAt.getHours(), endsAt.getHours())
+  grid-template-rows: ${({ "starts-at": startsAt, "ends-at": endsAt }) =>
+    rangeTimeBoxes(5, getHours(startsAt), getHours(endsAt))
       .map(t => `[t-${escapeTime(t)}]`)
       .join(" minmax(1em, max-content) ")};
 
@@ -43,25 +54,25 @@ const Grid = styled.div<{ startsAt: Date; endsAt: Date }>`
 `
 const Area = styled(_Link)<{
   track: Rooms
-  startsAt: string
-  endsAt: string
-  isBreak: boolean
+  ["starts-at"]: string
+  ["ends-at"]: string
+  ["$is-break"]: boolean
 }>`
   margin-bottom: 1em;
   padding: 1em;
   text-decoration: none;
   position: relative;
-  grid-column: ${({ track, isBreak }) =>
+  grid-column: ${({ track, "$is-break": isBreak }) =>
     isBreak ? `A / ${dummyTrack}` : track};
-  grid-row: ${({ startsAt, endsAt }) =>
+  grid-row: ${({ "starts-at": startsAt, "ends-at": endsAt }) =>
     `t-${escapeTime(startsAt)} / t-${escapeTime(endsAt)}`};
-  background-color: ${({ track, isBreak, theme, to }) =>
+  background-color: ${({ track, "$is-break": isBreak, theme, to }) =>
     rgba(
       isBreak ? theme.colors.disabled : theme.colors[`room${track}`],
       to ? 1.0 : 0.4,
     )};
   border-left: 5px solid;
-  border-color: ${({ track, isBreak, theme, to }) =>
+  border-color: ${({ track, "$is-break": isBreak, theme, to }) =>
     rgba(
       isBreak ? theme.colors.disabledText : theme.colors[`room${track}Border`],
       to ? 1.0 : 0.4,
@@ -89,7 +100,7 @@ const Area = styled(_Link)<{
     width: 16px;
     height: 16px;
     border-radius: 100%;
-    background-color: ${({ track, isBreak, theme }) =>
+    background-color: ${({ track, "$is-break": isBreak, theme }) =>
       isBreak ? theme.colors.disabledText : theme.colors[`room${track}Border`]};
   }
 
@@ -274,7 +285,7 @@ export default function SchedulePage() {
               <RoomLegendBox>
                 <RoomLegend />
               </RoomLegendBox>
-              <Grid startsAt={startsAt} endsAt={endsAt}>
+              <Grid starts-at={startsAt} ends-at={endsAt}>
                 {sessions.map(s => {
                   const hasDescription =
                     s.uuid && (s.speakers.length || s.sponsors.length)
@@ -294,9 +305,9 @@ export default function SchedulePage() {
                       }}
                       key={s.track + s.startsAt + s.endsAt}
                       track={s.track}
-                      startsAt={s.startsAt}
-                      endsAt={s.endsAt}
-                      isBreak={s.break}
+                      starts-at={s.startsAt}
+                      ends-at={s.endsAt}
+                      $is-break={s.break || false}
                     >
                       <AreaTitle>
                         <EventTime session={s} />

--- a/2024/src/pages/schedule.tsx
+++ b/2024/src/pages/schedule.tsx
@@ -2,7 +2,6 @@ import React, { useLayoutEffect } from "react"
 import styled from "styled-components"
 import { useTranslation } from "react-i18next"
 import { useStaticQuery, graphql } from "gatsby"
-import { Link as _Link } from "gatsby-link"
 import flatten from "lodash/flatten"
 
 import { Layout } from "../components/Layout"
@@ -20,6 +19,7 @@ import { Dates, times, Rooms, rooms } from "../util/misc"
 import { useEnOrJa } from "../util/languages"
 import { rgba } from "../util/rgba"
 import { Tags } from "../components/Tags"
+import { OptionalLink } from "../components/OptionalLink"
 
 const dummyTrack = String.fromCharCode(
   rooms[rooms.length - 1].charCodeAt(0) + 1,
@@ -52,7 +52,7 @@ const Grid = styled.div<{
     flex-direction: column;
   }
 `
-const Area = styled(_Link)<{
+const Area = styled(OptionalLink)<{
   track: Rooms
   ["starts-at"]: string
   ["ends-at"]: string
@@ -296,7 +296,6 @@ export default function SchedulePage() {
 
                   return (
                     <Area
-                      // @ts-expect-error
                       to={hasDescription ? `/talk/${s.uuid}` : null}
                       onClick={e => {
                         if (!hasDescription) {

--- a/2024/src/pages/speakers.tsx
+++ b/2024/src/pages/speakers.tsx
@@ -10,6 +10,11 @@ import { ResponsiveBox } from "../components/ResponsiveBox"
 import { Breadcrumb } from "../components/Breadcrumb"
 import { theme } from "../theme"
 
+export const Head = () => {
+  const { t } = useTranslation()
+  return <SEO title={t("speakers")} description={t("speakers.description")} />
+}
+
 export default function SpeakersPage() {
   const { allSpeakersYaml, allTalksYaml, allFile } = useStaticQuery(graphql`
     query Speakers {
@@ -66,7 +71,6 @@ export default function SpeakersPage() {
 
   return (
     <Layout background={theme.colors.bgLight}>
-      <SEO title={t("speakers")} description={t("speakers.description")} />
       <ResponsiveBox>
         <Breadcrumb path={[t("speakers")]} />
         <Title>{t("speakers")}</Title>

--- a/2024/src/pages/sponsors.tsx
+++ b/2024/src/pages/sponsors.tsx
@@ -9,6 +9,11 @@ import { SponsorList } from "../components/SponsorList"
 import { ResponsiveBox } from "../components/ResponsiveBox"
 import { Breadcrumb } from "../components/Breadcrumb"
 
+export const Head = () => {
+  const { t } = useTranslation()
+  return <SEO title={t("sponsors")} description={t("sponsors.description")} />
+}
+
 export default function SponsorsPage() {
   const data = useStaticQuery(graphql`
     query Sponsors {
@@ -30,7 +35,6 @@ export default function SponsorsPage() {
 
   return (
     <Layout>
-      <SEO title={t("sponsors")} description={t("sponsors.description")} />
       <ResponsiveBox>
         <Breadcrumb path={[t("sponsors")]} />
         <Title>{t("sponsors")}</Title>

--- a/2024/src/pages/venue.tsx
+++ b/2024/src/pages/venue.tsx
@@ -9,12 +9,16 @@ import { Address } from "../components/Address"
 import { ResponsiveBox } from "../components/ResponsiveBox"
 import { Breadcrumb } from "../components/Breadcrumb"
 
+export const Head = () => {
+  const { t } = useTranslation()
+  return <SEO title={t("venue")} description={t("venue.address")} />
+}
+
 export default function VenuePage() {
   const { t } = useTranslation()
 
   return (
     <Layout>
-      <SEO title={t("venue")} description={t("venue.address")} />
       <ResponsiveBox>
         <Breadcrumb path={[t("venue")]} />
 

--- a/2024/src/templates/markdown.tsx
+++ b/2024/src/templates/markdown.tsx
@@ -32,20 +32,29 @@ const Box = styled.div`
   font-family: ${({ theme }) => theme.fonts.header};
 `
 
-export default function Markdown(props: Props) {
+function useData(props: Props) {
   const {
     pageContext: { post },
   } = props
   const enOrJa = useEnOrJa()
-  const data = enOrJa(post.en, post.ja) ?? post.unknown
+  return enOrJa(post.en, post.ja) ?? post.unknown
+}
+
+export const Head = (props: Props) => {
+  const {
+    frontmatter: { title },
+  } = useData(props)
+  return <SEO title={title} />
+}
+
+export default function Markdown(props: Props) {
   const {
     frontmatter: { title },
     html,
-  } = data
+  } = useData(props)
 
   return (
     <Layout>
-      <SEO title={title} />
       <ResponsiveBox>
         <Breadcrumb path={[title]} />
         <Title>{title}</Title>

--- a/2024/src/templates/speaker.tsx
+++ b/2024/src/templates/speaker.tsx
@@ -221,6 +221,27 @@ const Youtube = ({ session: { youtube } }: YoutubeProps) => {
   )
 }
 
+export const Head = (props: Props) => {
+  const enOrJa = useEnOrJa()
+  const {
+    pageContext: { speakers, avatars, sponsors, talk },
+  } = props
+
+  const { title, titleJa } = talk
+
+  const speakerNames = speakers.length
+    ? speakers.map(s => s.name)
+    : sponsors.map(s => s.name)
+
+  return (
+    <SEO
+      title={`${enOrJa(title, titleJa)} - ${speakerNames}`}
+      // @ts-expect-error FIXME
+      ogImage={avatars.length ? avatars[0].images.sources : undefined}
+    />
+  )
+}
+
 export default function Speaker(props: Props) {
   const { t } = useTranslation()
   const enOrJa = useEnOrJa()
@@ -236,9 +257,6 @@ export default function Speaker(props: Props) {
     slideLanguage,
     track,
   } = talk
-  const speakerNames = speakers.length
-    ? speakers.map(s => s.name)
-    : sponsors.map(s => s.name)
 
   const location = speakers.length
     ? speakers[0]?.location ?? "on-site"
@@ -258,11 +276,6 @@ export default function Speaker(props: Props) {
 
   return (
     <Layout>
-      <SEO
-        title={`${enOrJa(title, titleJa)} - ${speakerNames}`}
-        // @ts-expect-error FIXME
-        ogImage={avatars.length ? avatars[0].images.sources : undefined}
-      />
       <ResponsiveBox>
         <Breadcrumb path={[{ label: t("speakers"), to: "/speakers" }, title]} />
         {speakers.map((speaker, i) => (


### PR DESCRIPTION
以下のワーニングを解決する PR になります。

1. リアクトは console.log の時に `defaultProps` が deprecated のワーニングが出たから 9a667be
1. StyledComponents を 6 にアップグレードの時にキャスタむプロパティーを変えないとワーニングになったから 044b73d
1. /* ts-expect-error */ のワークアラウンドを利用の代わりにOptional Component を利用するようになりました。 c6ff862
1. caniuse のパッケージはたまにアップデートしないといけないみたい b548f55
1. `npm start`の時に [Gatsby Head を利用するのワーニング](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/)ありました。 d744467
1. `npm start` すると gatsby types がアップデートになりますので、問題にならないようにコミットした 33d6fe0