### PR TITLE
Hide breaks that are not for the entire building in the mobile view

### DIFF
--- a/2024/src/templates/schedule.tsx
+++ b/2024/src/templates/schedule.tsx
@@ -170,6 +170,9 @@ const Area = styled(OptionalLink)<{
   ${({ theme }) => theme.breakpoints.mobile} {
     margin-bottom: 1em;
 
+    ${({ "$is-break": isBreak, track }) =>
+      isBreak && track !== "A" ? "display: none;" : ""}
+
     @media print {
       margin-bottom: 0.2em;
     }


### PR DESCRIPTION
With the merge of #400 there were "(Closed)" displays added for Track D to look cleaner on the print version. Unfortunately this looks weird in the mobile version. ↓

<img width="300" alt="Screenshot 2024-10-31 at 9 10 14" src="https://github.com/user-attachments/assets/cf18db60-3795-48ec-a618-7f35bb885572">

This PR hides all but the A breaks in the mobile view, removing confusion.

<img width="300" alt="Screenshot 2024-10-31 at 9 11 07" src="https://github.com/user-attachments/assets/f02fdc77-bf74-48f9-a496-db2852e934c2">
