### PR TITLE
残り時間表示の改善

### DIFF
--- a/2024/src/components/HeroCountdown.tsx
+++ b/2024/src/components/HeroCountdown.tsx
@@ -21,14 +21,17 @@ export const HeroCountdown = () => {
   if (duration.sign != 1) {
     return <></>
   }
+  const f = (time: number, unit: string) =>
+    `${time}${t(time === 1 ? `time.${unit}` : `time.${unit}s`)}`
   return (
     <Paragraph>
       {t("time.in")}
-      {duration.weeks ? `${duration.weeks}${t("time.weeks")}` : ""}
-      {duration.days ? `${duration.days}${t("time.days")}` : ""}
-      {duration.hours ? `${duration.hours}${t("time.hours")}` : ""}
-      {duration.minutes}
-      {t("time.minutes")}
+      {duration.weeks ? f(duration.weeks, "week") : ""}
+      {duration.weeks || duration.days ? f(duration.days, "day") : ""}
+      {duration.weeks || duration.days || duration.hours
+        ? f(duration.hours, "hour")
+        : ""}
+      {f(duration.minutes, "minute")}
     </Paragraph>
   )
 }

--- a/2024/src/i18n/en.ts
+++ b/2024/src/i18n/en.ts
@@ -76,8 +76,12 @@ export const en = {
     "talk.sponsor": "Sponsor Talks",
     "time.in": "in ",
     "time.weeks": " weeks ",
+    "time.week": " week ",
     "time.days": " days ",
+    "time.day": " day ",
     "time.hours": " hours ",
+    "time.hour": " hour ",
     "time.minutes": " minutes",
+    "time.minute": " minute",
   },
 }

--- a/2024/src/i18n/ja.ts
+++ b/2024/src/i18n/ja.ts
@@ -63,8 +63,11 @@ export const ja: {
     "talk.sponsor": "スポンサートーク",
     "time.in": "残り",
     "time.weeks": "週",
+    "time.week": "週",
     "time.days": "日",
+    "time.day": "日",
     "time.hours": "時",
+    "time.hour": "時",
     "time.minutes": "分",
   },
 }


### PR DESCRIPTION
- ゼロの場合は以前表示しなくなりました
- 英語の複数形のサポート

<img width="384" alt="Screenshot 2024-10-31 at 9 30 19" src="https://github.com/user-attachments/assets/70329214-1505-412c-a297-8572a70317b1">
