### PR TITLE
fix: title style

### DIFF
--- a/2024/src/components/Breadcrumb.tsx
+++ b/2024/src/components/Breadcrumb.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import { useTranslation } from "react-i18next"
 import { Link as _Link } from "gatsby"
+import Markdown from "react-markdown"
 
 export type Props = {
   path: (string | null | { label: string; to: string })[]
@@ -13,15 +14,15 @@ const Link = styled(_Link)`
 
 const Box = styled.div`
   display: flex;
+  flex-direction: row;
+  align-items: center;
 `
 const Text = styled.span`
   color: ${({ theme }) => theme.colors.textGrey};
   margin-right: 0.5em;
   font-size: 1.4rem;
   font-weight: bold;
-  text-transform: uppercase;
   font-family: ${({ theme }) => theme.fonts.header};
-  text-transform: uppercase;
 
   ${Link} & {
     &:hover {
@@ -57,7 +58,14 @@ export function Breadcrumb(props: Props) {
                   <Text>{path.label}</Text>
                 </Link>
               ) : (
-                <Text>{path.label}</Text>
+                <Text>
+                  <Markdown
+                    allowedElements={["p", "code"]}
+                    components={{ p: "span" }}
+                  >
+                    {path.label}
+                  </Markdown>
+                </Text>
               )}
             </React.Fragment>
           )

--- a/2024/src/data/talks.yaml
+++ b/2024/src/data/talks.yaml
@@ -364,7 +364,7 @@
     PBKDF2とは何ですか、使用方法、長所と短所
     Web Crypto API をより深く理解するためのデモ
     ユースケース
-    これらの Web Crypto API を使用して構築したアプリ - <https://cryptmoji.in>
+    これらの Web Crypto API を使用して構築したアプリ - <https://cryptmoji.in⁠>
     最後に
   spokenLanguage: en
   slideLanguage: en
@@ -604,10 +604,10 @@
   titleJa: "LT: romajip: 日本の住所CSVデータを活用した英語住所変換ライブラリを作った話"
   description: >-
     デジタル庁や郵便局は、日本の住所データをCSV形式で公開しています。romajipは、日本の都道府県、市区町村、郡まで含む複雑で巨大なデータセットを最適化されたJSONに変換し、日本語の住所を英語に変換するTypeScriptライブラリです。10分間のライトニングトークでは、romajipを作成した理由、データセット作成時に直面した課題、ライブラリとしてこだわった点などを紹介します。
-    github link: <https://github.com/Sangun-Kang/romajip>
+    github link: https://github.com/Sangun-Kang/romajip
   descriptionJa: >-
     デジタル庁や郵便局は、日本の住所データをCSV形式で公開しています。romajipは、日本の都道府県、市区町村、郡まで含む複雑で巨大なデータセットを最適化されたJSONに変換し、日本語の住所を英語に変換するTypeScriptライブラリです。10分間のライトニングトークでは、romajipを作成した理由、データセット作成時に直面した課題、ライブラリとしてこだわった点などを紹介します。
-    github link: <https://github.com/Sangun-Kang/romajip>
+    github link: https://github.com/Sangun-Kang/romajip
   spokenLanguage: ja
   slideLanguage: ja
   slidesUrl: ""
@@ -875,7 +875,7 @@
         - 更に、そのメリットを最大化するためのプラクティスとしてのOne Version Rule
     - One Version Rule with pnpmの実践的事例とその課題
         - monorepo内では1つのライブラリは1つのバージョンだけを参照するという仕組み
-            - <https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog>
+            - https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog
         - monorepoのインストールがシンプルになりセットアップをシンプルにする
         - プロダクトを一から作成するからこそ取れる選択肢、monorepo管理のアプローチ
         - 将来の拡張性を考えたpnpm catalogsの利用
@@ -897,11 +897,9 @@
 
     ## 発表の参考情報
 
-    - <https://j3t.ch/tech/modular-monolith-monorepo/>
-
-    - <https://monorepo.tools/>
-
-    - <https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog>
+    - https://j3t.ch/tech/modular-monolith-monorepo/
+    - https://monorepo.tools/
+    - https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog
   descriptionJa: >-
     ## イントロ
 
@@ -931,7 +929,7 @@
         - 更に、そのメリットを最大化するためのプラクティスとしてのOne Version Rule
     - One Version Rule with pnpmの実践的事例とその課題
         - monorepo内では1つのライブラリは1つのバージョンだけを参照するという仕組み
-            - <https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog>
+            - https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog
         - monorepoのインストールがシンプルになりセットアップをシンプルにする
         - プロダクトを一から作成するからこそ取れる選択肢、monorepo管理のアプローチ
         - 将来の拡張性を考えたpnpm catalogsの利用
@@ -953,12 +951,9 @@
 
     ## 発表の参考情報
 
-    - <https://j3t.ch/tech/modular-monolith-monorepo/>
-
-    - <https://monorepo.tools/>
-
-    - <https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog>
-
+    - https://j3t.ch/tech/modular-monolith-monorepo/
+    - https://monorepo.tools/
+    - https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog
   spokenLanguage: ja
   slideLanguage: ja
   slidesUrl: ""

--- a/2024/src/data/talks.yaml
+++ b/2024/src/data/talks.yaml
@@ -604,10 +604,10 @@
   titleJa: "LT: romajip: 日本の住所CSVデータを活用した英語住所変換ライブラリを作った話"
   description: >-
     デジタル庁や郵便局は、日本の住所データをCSV形式で公開しています。romajipは、日本の都道府県、市区町村、郡まで含む複雑で巨大なデータセットを最適化されたJSONに変換し、日本語の住所を英語に変換するTypeScriptライブラリです。10分間のライトニングトークでは、romajipを作成した理由、データセット作成時に直面した課題、ライブラリとしてこだわった点などを紹介します。
-    github link: https://github.com/Sangun-Kang/romajip
+    github link: <https://github.com/Sangun-Kang/romajip>
   descriptionJa: >-
     デジタル庁や郵便局は、日本の住所データをCSV形式で公開しています。romajipは、日本の都道府県、市区町村、郡まで含む複雑で巨大なデータセットを最適化されたJSONに変換し、日本語の住所を英語に変換するTypeScriptライブラリです。10分間のライトニングトークでは、romajipを作成した理由、データセット作成時に直面した課題、ライブラリとしてこだわった点などを紹介します。
-    github link: https://github.com/Sangun-Kang/romajip
+    github link: <https://github.com/Sangun-Kang/romajip>
   spokenLanguage: ja
   slideLanguage: ja
   slidesUrl: ""
@@ -875,7 +875,7 @@
         - 更に、そのメリットを最大化するためのプラクティスとしてのOne Version Rule
     - One Version Rule with pnpmの実践的事例とその課題
         - monorepo内では1つのライブラリは1つのバージョンだけを参照するという仕組み
-            - https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog
+            - <https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog>
         - monorepoのインストールがシンプルになりセットアップをシンプルにする
         - プロダクトを一から作成するからこそ取れる選択肢、monorepo管理のアプローチ
         - 将来の拡張性を考えたpnpm catalogsの利用
@@ -897,9 +897,11 @@
 
     ## 発表の参考情報
 
-    - https://j3t.ch/tech/modular-monolith-monorepo/
-    - https://monorepo.tools/
-    - https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog
+    - <https://j3t.ch/tech/modular-monolith-monorepo/>
+
+    - <https://monorepo.tools/>
+
+    - <https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog>
   descriptionJa: >-
     ## イントロ
 
@@ -929,7 +931,7 @@
         - 更に、そのメリットを最大化するためのプラクティスとしてのOne Version Rule
     - One Version Rule with pnpmの実践的事例とその課題
         - monorepo内では1つのライブラリは1つのバージョンだけを参照するという仕組み
-            - https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog
+            - <https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog>
         - monorepoのインストールがシンプルになりセットアップをシンプルにする
         - プロダクトを一から作成するからこそ取れる選択肢、monorepo管理のアプローチ
         - 将来の拡張性を考えたpnpm catalogsの利用
@@ -951,9 +953,12 @@
 
     ## 発表の参考情報
 
-    - https://j3t.ch/tech/modular-monolith-monorepo/
-    - https://monorepo.tools/
-    - https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog
+    - <https://j3t.ch/tech/modular-monolith-monorepo/>
+
+    - <https://monorepo.tools/>
+
+    - <https://tech.newmo.me/entry/one-version-rule-built-on-pnpm-catalog>
+
   spokenLanguage: ja
   slideLanguage: ja
   slidesUrl: ""

--- a/2024/src/data/talks.yaml
+++ b/2024/src/data/talks.yaml
@@ -364,7 +364,7 @@
     PBKDF2とは何ですか、使用方法、長所と短所
     Web Crypto API をより深く理解するためのデモ
     ユースケース
-    これらの Web Crypto API を使用して構築したアプリ - <https://cryptmoji.in⁠>
+    これらの Web Crypto API を使用して構築したアプリ - <https://cryptmoji.in>
     最後に
   spokenLanguage: en
   slideLanguage: en

--- a/2024/src/templates/schedule.tsx
+++ b/2024/src/templates/schedule.tsx
@@ -1,3 +1,4 @@
+import Markdown from "react-markdown"
 import React, { useLayoutEffect } from "react"
 import styled from "styled-components"
 import { useTranslation } from "react-i18next"
@@ -490,7 +491,14 @@ export default function SchedulePage({
                         <EventTime session={s} />
                       </AreaTitle>
                       <EventEntry>
-                        <Text>{getSessionName(s, allSessions)}</Text>
+                        <Text>
+                          <Markdown
+                            allowedElements={["p", "code"]}
+                            components={{ p: "span" }}
+                          >
+                            {getSessionName(s, allSessions)}
+                          </Markdown>
+                        </Text>
                         <EventSpeakers session={s} />
 
                         <AreaFooter>

--- a/2024/src/templates/speaker.tsx
+++ b/2024/src/templates/speaker.tsx
@@ -91,7 +91,6 @@ const TalkBox = styled.div<{
   }
 `
 const TalkTitle = styled.h2`
-  text-transform: uppercase;
   font-family: ${({ theme }) => theme.fonts.header};
   margin: 0.5em 0;
   font-size: ${({ theme }) => theme.fontSizes.subTitle};
@@ -323,7 +322,14 @@ export default function Speaker(props: Props) {
         <Room track={track} />
         <TalkBox track={track}>
           <EventTime session={talk} />
-          <TalkTitle>{enOrJa(title, titleJa)}</TalkTitle>
+          <TalkTitle>
+            <Markdown
+              allowedElements={["p", "code"]}
+              components={{ p: "span" }}
+            >
+              {enOrJa(title, titleJa)}
+            </Markdown>
+          </TalkTitle>
           <Tags>{langTags}</Tags>
           <Markdown>{enOrJa(description, descriptionJa)}</Markdown>
           <Slides session={talk} />


### PR DESCRIPTION
変更内容

* 発表タイトルにMarkdownが含まれる場合にParseされるように調整しました。
* 発表タイトルの大文字・小文字に意味があるケースがあったため、`uppercase`のスタイルを削除しました（この変更が不要な場合はご指摘ください）
* パンくずリストのスタイルを調整しました

対応ページ

* https://deploy-preview-502--jsconf-jp-preview.netlify.app/2024/talk/yuji-sugiura/

タイトルの大文字小文字が意味があるようなページ

* https://deploy-preview-502--jsconf-jp-preview.netlify.app/2024/talk/earthbrain/
* https://deploy-preview-502--jsconf-jp-preview.netlify.app/2024/talk/mizdra/