### PR TITLE
fix: a11y issues on button contrast ratio

### DIFF
--- a/2025/src/app/[locale]/page.tsx
+++ b/2025/src/app/[locale]/page.tsx
@@ -44,7 +44,7 @@ export default function Home({ params }: Props) {
           <Button
             full
             variant="primary"
-            size="lg"
+            size="xl"
             href={CFP_FORM_URL}
             target="_blank"
             endIcon={<ArrowTopRightOnSquareIcon className="w-4 h-4" />}
@@ -54,7 +54,7 @@ export default function Home({ params }: Props) {
           <Button
             full
             variant="primary"
-            size="lg"
+            size="xl"
             href={SPONSOR_FORM_URL}
             target="_blank"
             endIcon={<ArrowTopRightOnSquareIcon className="w-4 h-4" />}


### PR DESCRIPTION
I tried various colors to maintain a certain contrast ratio, but decided that none of them matched the atmosphere of the site.
According to the definition of contrast ratio, even with the current colors, large text would pass, so I solved the problem by changing the size of the buttons.

![image](https://github.com/user-attachments/assets/fc9936d7-a6a4-42f0-b243-e690cd227867)

![image](https://github.com/user-attachments/assets/9bd26caa-66d3-455c-ae2e-aa51e75f33af)
