### PR TITLE
fix: do not use dynamic class name

### DIFF
--- a/2025/src/components/Chip.tsx
+++ b/2025/src/components/Chip.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import React from "react";
 import { Track } from "@/constants/schedule";
+import { getTrackClassNames } from "@/lib/getTrackClassNames";
 
 type Props = {
   track?: Track;
@@ -18,7 +19,7 @@ export function Chip({
         "flex rounded-md font-bold",
         size === "default" ? "py-1 px-4 text-sm" : "py-0.5 px-2 text-xs",
         track && track !== "all"
-          ? `bg-track-${track.toLowerCase()} text-track-${track.toLowerCase()}-surface`
+          ? getTrackClassNames(track)
           : "bg-secondary text-white"
       )}
     >

--- a/2025/src/components/TimeTable.tsx
+++ b/2025/src/components/TimeTable.tsx
@@ -5,6 +5,7 @@ import { SessionCard } from "@/components/SessionCard";
 import { SCHEDULE, TRACKS } from "@/constants/schedule";
 import { generateSessionId } from "@/lib/generateSessionId";
 import { generateTimeSlots } from "@/lib/generateTimeSlots";
+import { getTrackClassNames } from "@/lib/getTrackClassNames";
 import { timeToMinutes } from "@/lib/timeToMinutes";
 import { TalkSessionCard } from "./TalkSessionCard";
 
@@ -57,7 +58,7 @@ export function TimeTable() {
               <div
                 className={clsx(
                   "w-6 h-6 rounded-full",
-                  `bg-track-${track.toLowerCase()}`
+                  getTrackClassNames(track)
                 )}
               />
               {t(track)}

--- a/2025/src/lib/getTrackClassNames.ts
+++ b/2025/src/lib/getTrackClassNames.ts
@@ -1,0 +1,16 @@
+import { Track } from "@/constants/schedule";
+
+export function getTrackClassNames(track: Track): string {
+  switch (track) {
+    case "A":
+      return "bg-track-a text-track-a-surface";
+    case "B":
+      return "bg-track-b text-track-b-surface";
+    case "C":
+      return "bg-track-c text-track-c-surface";
+    case "D":
+      return "bg-track-d text-track-d-surface";
+    default:
+      return "bg-secondary text-white";
+  }
+}


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/17f1c00f-b948-414e-ae85-a6c94357124b)

> Dynamic class names
> Since Tailwind scans your source files as plain text, it has no way of understanding string concatenation or interpolation in the programming language you're using.
>
> &mdash; [Detecting classes in source files - Core concepts - Tailwind CSS](https://tailwindcss.com/docs/detecting-classes-in-source-files#dynamic-class-names)