### PR TITLE
ci: target 2026 in the screenshots workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,21 +12,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: 2025/.nvmrc
+          node-version-file: 2026/.nvmrc
           cache: npm
-          cache-dependency-path: 2025/package-lock.json
-      - run: cd 2025 && npm ci
-      - run: cd 2025 && npm run dev &
+          cache-dependency-path: 2026/package-lock.json
+      - run: cd 2026 && npm ci
+      - run: cd 2026 && npm run dev &
         env:
           PORT: 3001
-      - run: cd 2025 && npx playwright install --with-deps
-      - run: cd 2025 && npx playwright test
-      - run: cd 2025 && npm run fetch-og-images
+      - run: cd 2026 && npx playwright install --with-deps
+      - run: cd 2026 && npx playwright test
+      - run: cd 2026 && npm run fetch-og-images
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: screenshots
-          path: 2025/screenshots/**/*
+          path: 2026/screenshots/**/*
           retention-days: 7
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary
The `screenshots` (Playwright) workflow still targeted **2025**, which is now frozen. Point it at **2026** (the active site), matching the CI test/build jobs.

### Change
- `.github/workflows/playwright.yml`: `2025` → `2026` — setup-node `.nvmrc`, npm cache path, `cd 2026` for `npm ci` / `dev` / `playwright install` / `playwright test` / `fetch-og-images`, and the uploaded screenshots artifact path.

The screenshots spec only captures and uploads page screenshots (no baseline assertions), so it runs fine against 2026's pre-announcement (empty) data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
