### PR TITLE
feat(2026): add previous year highlight video

### DIFF
--- a/2026/messages/en.json
+++ b/2026/messages/en.json
@@ -4,7 +4,8 @@
     "description": "jsconf.jp is a JavaScript festival in Japan powered by Japan Node.js Association. This is the seventh time event of jsconf in Japan. We would love to become a bridge between Japanese Web Developers and International Web Developers.",
     "eventDate": "November 22, 2026 (Sun)",
     "companyAddress": "〒210-0024 27-7-903 Nisshincho Kawasaki-ku Kawasaki-shi Kanagawa",
-    "copyright": "© 2019-2026 JSConf JP"
+    "copyright": "© 2019-2026 JSConf JP",
+    "previousYearHighlights": "Last year's highlights"
   },
   "navigation": {
     "speakers": "Speakers",

--- a/2026/messages/ja.json
+++ b/2026/messages/ja.json
@@ -4,7 +4,8 @@
     "description": "jsconf.jp is a JavaScript festival in Japan powered by Japan Node.js Association. This is the seventh time event of jsconf in Japan. We would love to become a bridge between Japanese Web Developers and International Web Developers.",
     "eventDate": "2026年11月22日（日）",
     "companyAddress": "〒210-0024 神奈川県川崎市川崎区日進町27-7-903",
-    "copyright": "© 2019-2026 JSConf JP"
+    "copyright": "© 2019-2026 JSConf JP",
+    "previousYearHighlights": "去年のハイライト"
   },
   "navigation": {
     "speakers": "スピーカー",

--- a/2026/src/app/[locale]/page.tsx
+++ b/2026/src/app/[locale]/page.tsx
@@ -78,7 +78,7 @@ export default async function Page({ params }: Props) {
         </div>
       </div>
 
-      <div className="max-w-screen-md mx-auto mt-8 md:mt-16 flex flex-col gap-4 px-4 lg:px-0">
+      <div className="max-w-3xl mx-auto mt-8 md:mt-16 flex flex-col gap-4 px-4 lg:px-0">
         <h2 className="text-lg md:text-xl font-bold text-center">
           {t("about.previousYearHighlights")}
         </h2>

--- a/2026/src/app/[locale]/page.tsx
+++ b/2026/src/app/[locale]/page.tsx
@@ -78,6 +78,23 @@ export default async function Page({ params }: Props) {
         </div>
       </div>
 
+      <div className="max-w-screen-md mx-auto mt-8 md:mt-16 flex flex-col gap-4 px-4 lg:px-0">
+        <h2 className="text-lg md:text-xl font-bold text-center">
+          {t("about.previousYearHighlights")}
+        </h2>
+        <div className="w-full aspect-video">
+          <iframe
+            className="w-full h-full"
+            src="https://www.youtube.com/embed/me9KQ1SpKK4?si=byHOxwIpCcctOFyE"
+            title="YouTube video player"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerPolicy="strict-origin-when-cross-origin"
+            allowFullScreen
+          />
+        </div>
+      </div>
+
       {SPONSORS.length > 0 && (
         <div className="max-w-3xl mx-auto mt-8 md:mt-32 flex flex-col gap-4">
           <h2 className="text-3xl font-bold text-center">


### PR DESCRIPTION
## `/ja`

<img width="1320" height="1035" alt="image" src="https://github.com/user-attachments/assets/ab2d30b6-0bf2-442e-af7f-c05d4cba6da5" />

## `/en`

<img width="1320" height="1035" alt="image" src="https://github.com/user-attachments/assets/92eb01cf-0c1a-49ad-bb8f-c1a4262b9683" />
