### PR TITLE
feat(schedule): sync 2026 timetable with latest spreadsheet

### DIFF
--- a/2026/src/constants/schedule.ts
+++ b/2026/src/constants/schedule.ts
@@ -107,8 +107,9 @@ const notSortedSchedule: ScheduledSession[] = [
   talkSession("A", "11:45", "11:50", "miidas-sponsor-lt-1"),
   talkSession("A", "11:50", "11:55", "anotherball-sponsor-lt-1"),
   talkSession("A", "11:55", "12:00", "cybozu-sponsor-lt-1"),
+  talkSession("A", "12:00", "12:05", "mcd3-sponsor-lt"),
 
-  eventSession("break", "all", "12:00", "13:00", "昼休憩"),
+  eventSession("break", "all", "12:05", "13:00", "昼休憩"),
 
   ...trackTalks("13:00", "13:30", [
     "devlin-duldulao",
@@ -130,40 +131,40 @@ const notSortedSchedule: ScheduledSession[] = [
     "cybozu-sponsor-session",
   ]),
   ...trackTalks("14:40", "15:10", [
-    "williams-kwan",
+    "ondrej-zara",
     "wataru-morita",
     "html-in-canvas-api",
     "arkor-sponsor-session",
   ]),
   eventSession("break", "all", "15:10", "15:20"),
   ...trackTalks("15:20", "15:50", [
-    "ondrej-zara",
+    "brandon-dail",
     "eiji",
     "kevin-uehara",
     "dwango-sponsor-session",
   ]),
   ...trackTalks("15:50", "16:20", [
-    "brandon-dail",
+    "saman-abaasi",
     "roland-richard",
     "enechain-sponsor-session",
     "supateam-sponsor-session",
   ]),
   eventSession("break", "all", "16:20", "16:30"),
   ...trackTalks("16:30", "17:00", [
-    "saman-abaasi",
+    "itai-satati",
     "akfm-sato",
     "ncdc-sponsor-session",
     "lincwell-sponsor-session",
   ]),
   ...trackTalks("17:00", "17:30", [
-    "itai-satati",
+    "leo-kettmeir",
     "kinocoboy",
     "cougar-sponsor-session",
     "money-forward-sponsor-session",
   ]),
   ...trackTalks("17:30", "18:00", [
-    "leo-kettmeir",
     "jessie",
+    "gmo-flatt-security-sponsor-session",
     "vercel-sponsor-session",
     "layerx-sponsor-session",
   ]),
@@ -180,7 +181,7 @@ const notSortedSchedule: ScheduledSession[] = [
   talkSession("A", "18:50", "18:55", "cougar-sponsor-lt"),
   talkSession("A", "18:55", "19:00", "vercel-sponsor-lt"),
   talkSession("A", "19:00", "19:05", "gmo-flatt-security-sponsor-lt"),
-  talkSession("A", "19:05", "19:10", "geekneer-sponsor-lt"),
+  talkSession("A", "19:05", "19:10", "everlane-sponsor-lt"),
 
   eventSession("closed", "A", "19:10", "19:40", "Room A Close (懇親会準備)"),
   talkSession("B", "19:10", "19:40", "josh-junon"),

--- a/2026/src/constants/talks.ts
+++ b/2026/src/constants/talks.ts
@@ -203,6 +203,7 @@ export const TALKS = [
     "sponsor LT",
     "Japanese",
   ),
+  makeTalk("mcd3-sponsor-lt", "MCD3株式会社 LT", "sponsor LT", "Japanese"),
   makeTalk(
     "devlin-duldulao",
     "Secure by Default Is a Lie — Unless You Make It the Default",
@@ -271,13 +272,6 @@ export const TALKS = [
     "サイボウズ株式会社",
     "sponsor session",
     "Japanese",
-  ),
-  makeTalk(
-    "williams-kwan",
-    "Mono Repo, Multi Region: Mercari Frontend Architecture",
-    "session",
-    "English",
-    ["Williams Kwan"],
   ),
   makeTalk(
     "wataru-morita",
@@ -420,6 +414,12 @@ export const TALKS = [
   ),
   makeTalk("vercel-sponsor-session", "Vercel", "sponsor session", "English"),
   makeTalk(
+    "gmo-flatt-security-sponsor-session",
+    "GMO Flatt Security株式会社",
+    "sponsor session",
+    "Japanese",
+  ),
+  makeTalk(
     "layerx-sponsor-session",
     "株式会社LayerX",
     "sponsor session",
@@ -446,12 +446,7 @@ export const TALKS = [
     "sponsor LT",
     "Japanese",
   ),
-  makeTalk(
-    "geekneer-sponsor-lt",
-    "株式会社ギークニア LT",
-    "sponsor LT",
-    "Japanese",
-  ),
+  makeTalk("everlane-sponsor-lt", "株式会社EVERLANE LT", "sponsor LT", "Japanese"),
   makeTalk(
     "josh-junon",
     "基調講演2: Yep, I've Been Pwned: What I Learned from Being Hacked",


### PR DESCRIPTION
## Summary

2026 のタイムテーブルを[最新のスプレッドシート](https://docs.google.com/spreadsheets/d/1BrITmMkjCyL-gDyuIz0iRg5_7nAh3Dv153giHqce-Ik/edit?gid=0#gid=0)に合わせて更新しました。

- **MCD3株式会社 LT を追加**（12:00-12:05, Room A）。昼休憩の開始を 12:05 に変更
- **Williams Kwan（Mercari）のセッションを削除**。Room A の午後セッションを 1 枠ずつ前倒し（Ondřej Žára 14:40 → Brandon Dail 15:20 → Saman Abaasi 15:50 → Itai Satati 16:30 → Leo Kettmeir 17:00 → Jessie 17:30）
- **GMO Flatt Security株式会社 スポンサーセッションを追加**（17:30-18:00, Room B）
- **19:05 のスポンサー LT を 株式会社ギークニア → 株式会社EVERLANE に差し替え**

## Notes

- Williams Kwan のトークはスピーカー一覧が `TALKS` を直接参照するため、`schedule.ts` だけでなく `talks.ts` からも外しています（残すとスピーカー一覧から存在しないトークページへリンクしてしまうため）。`speakerProfiles.json` / `talkDescriptions.json` / アバター画像は復活時に備えて残しています。
- `public/sponsor/geekneer.png` は EVERLANE が社名変更か別スポンサーか判断できないため、そのままにしています。

## Test plan

- [x] スプレッドシートの全セル（時間・トラック・ラベル）と `SCHEDULE` を機械的に突き合わせ、不足・余剰ゼロを確認
- [x] `npm run lint` / `npm test`（31 件）/ `next build` が成功
- [x] 新規トークページ（`mcd3-sponsor-lt`, `gmo-flatt-security-sponsor-session`, `everlane-sponsor-lt`）が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhfGfFhqbUpHugi5ka4jcf
