### PR TITLE
OG画像URL修正

### DIFF
--- a/2026/src/app/layout.tsx
+++ b/2026/src/app/layout.tsx
@@ -10,7 +10,7 @@ export const viewport: Viewport = {
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
-    metadataBase: new URL("https://jsconf.jp"),
+    metadataBase: new URL("https://jsconf.jp/2026"),
     title: {
       template: `%s | ${en.about.title}`,
       default: en.about.title,


### PR DESCRIPTION
## WHY

https://jsconf.jp/2026/ja/talks/tomikawa-sotaro のOG画像が
https://jsconf.jp/ja/talks/tomikawa-sotaro/opengraph-image?33251a403acd67b4 に解決され404

## WHAT

https://jsconf.jp/2026/ja/talks/tomikawa-sotaro/opengraph-image?33251a403acd67b4 が正規のURLだと思われる

metadataBaseに `/2026` を付与